### PR TITLE
Add test reports to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: cloudcoil/cloudcoil
     
-    
-    
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+  

--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ processed_swagger.json
 extra_data.json
 .DS_Store
 .vscode
+junit.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ select = [
 ignore = ["E203", "B008", "N818", "E501", "B904"]
 
 [tool.pytest.ini_options]
-addopts = "-ra -q --cov=cloudcoil --cov-report=xml --cov-report=term -vvv"
+addopts = "-ra -q --cov=cloudcoil --cov-report=xml --cov-report=term -vvv --junitxml=junit.xml -o junit_family=legacy"
 testpaths = ["tests"]
 markers = ["configure_test_cluster: Configure cloudcoil test cluster"]
 


### PR DESCRIPTION
This pull request includes changes to the CI workflow and the `pyproject.toml` configuration file to improve test result reporting and integration with Codecov.

CI workflow improvements:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL48-R52): Added a step to upload test results to Codecov using the `codecov/test-results-action@v1` action, conditioned on the workflow not being cancelled.

Test configuration enhancements:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L50-R50): Updated `addopts` in the `[tool.pytest.ini_options]` section to include options for generating a JUnit XML report and setting the JUnit family to legacy.