### PR TITLE
Add async tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "httpx",
     "pyyaml>=6.0.2",
     "typing_extensions>=4.0.0; python_version <= '3.10'",
+    "pytest-asyncio>=0.25.0",
 ]
 keywords = ["cloud-native", "kubernetes", "pydantic", "python", "async"]
 
@@ -50,6 +51,7 @@ ignore = ["E203", "B008", "N818", "E501", "B904"]
 addopts = "-ra -q --cov=cloudcoil --cov-report=xml --cov-report=term -vvv --junitxml=junit.xml -o junit_family=legacy"
 testpaths = ["tests"]
 markers = ["configure_test_cluster: Configure cloudcoil test cluster"]
+asyncio_mode = "auto"
 
 [dependency-groups]
 dev = [

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -15,3 +15,16 @@ def test_e2e(test_client_set):
         assert corev1.Namespace.get(name).metadata.name == name
         assert output.remove().metadata.name == name
         assert corev1.Namespace.delete(name).status.phase == "Terminating"
+
+
+@pytest.mark.configure_test_cluster(cluster_name="test-cloudcoil", remove=False)
+async def test_async_e2e(test_client_set):
+    with test_client_set:
+        assert (
+            await corev1.Service.async_get("kubernetes", "default")
+        ).metadata.name == "kubernetes"
+        output = await corev1.Namespace(metadata=ObjectMeta(generate_name="test-")).async_create()
+        name = output.metadata.name
+        assert (await corev1.Namespace.async_get(name)).metadata.name == name
+        assert (await output.async_remove()).metadata.name == name
+        assert (await corev1.Namespace.async_delete(name)).status.phase == "Terminating"

--- a/uv.lock
+++ b/uv.lock
@@ -256,6 +256,7 @@ source = { editable = "." }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
+    { name = "pytest-asyncio" },
     { name = "pyyaml" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
@@ -285,6 +286,7 @@ dev = [
 requires-dist = [
     { name = "httpx" },
     { name = "pydantic", specifier = ">2.0" },
+    { name = "pytest-asyncio", specifier = ">=0.25.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.0" },
 ]
@@ -1309,6 +1311,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/18/82fcb4ee47d66d99f6cd1efc0b11b2a25029f303c599a5afda7c1bca4254/pytest_asyncio-0.25.0.tar.gz", hash = "sha256:8c0610303c9e0442a5db8604505fc0f545456ba1528824842b37b4a626cbf609", size = 53298 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/56/2ee0cab25c11d4e38738a2a98c645a8f002e2ecf7b5ed774c70d53b92bb1/pytest_asyncio-0.25.0-py3-none-any.whl", hash = "sha256:db5432d18eac6b7e28b46dcd9b69921b55c3b1086e85febfe04e70b18d9e81b3", size = 19245 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request includes changes to add support for asynchronous testing and improve the testing configuration. The most important changes include adding a new dependency for asyncio support, updating the testing configuration to enable asyncio mode, and adding a new asynchronous end-to-end test.

### Dependencies and Configuration:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R21): Added `pytest-asyncio>=0.25.0` to the dependencies list to support asynchronous testing.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R54): Added `asyncio_mode = "auto"` to the testing configuration to enable automatic asyncio mode.

### Testing:

* [`tests/test_e2e.py`](diffhunk://#diff-ed3b8af48cd21dc1ac735b839d89b172a6f45569c324af70a2bdb4f60e5fbcddR18-R28): Added a new asynchronous end-to-end test `test_async_e2e` to test asynchronous operations using `pytest-asyncio`.