### PR TITLE
Minor pyproject.toml fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "httpx",
     "pyyaml>=6.0.2",
     "typing_extensions>=4.0.0; python_version <= '3.10'",
-    "pytest-asyncio>=0.25.0",
 ]
 keywords = ["cloud-native", "kubernetes", "pydantic", "python", "async"]
 
@@ -35,7 +34,7 @@ build-backend = "hatchling.build"
 
 [tool.ruff]
 line-length = 100
-target-version = "py38"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = [
@@ -69,6 +68,7 @@ dev = [
     "types-pyyaml>=6.0.12.20241221",
     "ipython>=8.12.3",
     "pytest-sugar>=1.0.0",
+    "pytest-asyncio>=0.25.0",
 ]
 
 [tool.mypy]

--- a/tests/test_clientset.py
+++ b/tests/test_clientset.py
@@ -134,10 +134,11 @@ def test_incluster_initialization(tmp_path):
     token_path.write_text("test-token")
     namespace_path.write_text("test-namespace")
 
-    with patch("cloudcoil.client._client_set.INCLUSTER_TOKEN_PATH", token_path), patch(
-        "cloudcoil.client._client_set.INCLUSTER_CERT_PATH", ca_path
-    ), patch("cloudcoil.client._client_set.DEFAULT_KUBECONFIG", tmp_path / "dne"), patch(
-        "cloudcoil.client._client_set.INCLUSTER_NAMESPACE_PATH", namespace_path
+    with (
+        patch("cloudcoil.client._client_set.INCLUSTER_TOKEN_PATH", token_path),
+        patch("cloudcoil.client._client_set.INCLUSTER_CERT_PATH", ca_path),
+        patch("cloudcoil.client._client_set.DEFAULT_KUBECONFIG", tmp_path / "dne"),
+        patch("cloudcoil.client._client_set.INCLUSTER_NAMESPACE_PATH", namespace_path),
     ):
         client = ClientSet()
         assert client.server == "https://kubernetes.default.svc"

--- a/uv.lock
+++ b/uv.lock
@@ -256,7 +256,6 @@ source = { editable = "." }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
-    { name = "pytest-asyncio" },
     { name = "pyyaml" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
@@ -275,6 +274,7 @@ dev = [
     { name = "mkdocstrings-python", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '4.0'" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '4.0'" },
     { name = "pytest-cov", version = "6.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '4.0'" },
     { name = "pytest-sugar" },
@@ -286,7 +286,6 @@ dev = [
 requires-dist = [
     { name = "httpx" },
     { name = "pydantic", specifier = ">2.0" },
-    { name = "pytest-asyncio", specifier = ">=0.25.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.0" },
 ]
@@ -303,6 +302,7 @@ dev = [
     { name = "mkdocstrings-python", specifier = ">=1.7.5" },
     { name = "mypy" },
     { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-asyncio", specifier = ">=0.25.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-sugar", specifier = ">=1.0.0" },
     { name = "ruff", specifier = ">=0.8.4" },


### PR DESCRIPTION
This pull request includes several changes to the `pyproject.toml` file and a test case in `tests/test_clientset.py`. The most important changes involve updating dependencies and modifying a test case to improve readability.

Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L21): Removed `pytest-asyncio` from the main dependencies section and added it to the `dev` dependencies section. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L21) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R71)
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L38-R37): Updated the `target-version` for `ruff` from `py38` to `py310`.

Test case improvement:

* [`tests/test_clientset.py`](diffhunk://#diff-93cf6a70d2ed7469f062a94e1bb373e4ec16c8a7d52b998b28de48ae83f793fbL137-R141): Refactored the `test_incluster_initialization` function to use a more readable context manager syntax for patching multiple paths.