### PR TITLE
Rename to config and add testing docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ fix-lint:
 
 .PHONY: docs-serve
 docs-serve:
+	rm -rf docs/index.md
+	cp README.md docs/index.md
 	uv run mkdocs serve
 
 .PHONY: prepare-for-pr

--- a/cloudcoil/_testing/plugin.py
+++ b/cloudcoil/_testing/plugin.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import httpx
 
-from cloudcoil.client import ClientSet
+from cloudcoil.client import Config
 
 DEFAULT_K3D_VERSION = "v5.7.5"
 DEFAULT_K8S_VERSION = "v1.31.4"
@@ -78,5 +78,5 @@ def test_cluster(request):
 
 
 @pytest.fixture
-def test_client_set(test_cluster):
-    yield ClientSet(kubeconfig=test_cluster)
+def test_config(test_cluster):
+    yield Config(kubeconfig=test_cluster)

--- a/cloudcoil/client/__init__.py
+++ b/cloudcoil/client/__init__.py
@@ -1,5 +1,5 @@
 from ._api_client import APIClient, AsyncAPIClient
-from ._client_set import ClientSet
+from ._config import Config
 from ._resource import Resource, ResourceList
 
-__all__ = ["ClientSet", "Resource", "APIClient", "AsyncAPIClient", "ResourceList"]
+__all__ = ["Config", "Resource", "APIClient", "AsyncAPIClient", "ResourceList"]

--- a/cloudcoil/client/_context.py
+++ b/cloudcoil/client/_context.py
@@ -2,38 +2,38 @@ from contextvars import ContextVar
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from cloudcoil.client._client_set import ClientSet
+    from cloudcoil.client._config import Config
 
-_clientsets = ContextVar("_clientsets", default=None)
+_configs = ContextVar("_configs", default=None)
 
 
 class _Context:
-    def _enter(self, clientset: "ClientSet") -> None:
-        if self.clientsets is None:
-            self.clientsets = []
-        self.clientsets.append(clientset)
+    def _enter(self, config: "Config") -> None:
+        if self.configs is None:
+            self.configs = []
+        self.configs.append(config)
 
     def _exit(self) -> None:
-        if self.clientsets:
-            self.clientsets.pop()
+        if self.configs:
+            self.configs.pop()
 
     @property
-    def active_client_set(self) -> "ClientSet":
-        if not self.clientsets:
-            from cloudcoil.client._client_set import ClientSet
+    def active_config(self) -> "Config":
+        if not self.configs:
+            from cloudcoil.client._config import Config
 
-            clientset = ClientSet()
-            clientset.initialize()
-            self.clientsets = [clientset]
-        return self.clientsets[-1]
+            config = Config()
+            config.initialize()
+            self.configs = [config]
+        return self.configs[-1]
 
     @property
-    def clientsets(self) -> list["ClientSet"] | None:
-        return _clientsets.get()
+    def configs(self) -> list["Config"] | None:
+        return _configs.get()
 
-    @clientsets.setter
-    def clientsets(self, value) -> None:
-        _clientsets.set(value)
+    @configs.setter
+    def configs(self, value) -> None:
+        _configs.set(value)
 
 
 context = _Context()

--- a/cloudcoil/client/_resource.py
+++ b/cloudcoil/client/_resource.py
@@ -37,38 +37,36 @@ class Resource(BaseResource):
 
     @classmethod
     def get(cls, name: str, namespace: str | None = None) -> Self:
-        client_set = context.active_client_set
-        return client_set.client_for(cls, sync=True).get(name, namespace)
+        config = context.active_config
+        return config.client_for(cls, sync=True).get(name, namespace)
 
     @classmethod
     async def async_get(cls, name: str, namespace: str | None = None) -> Self:
-        client_set = context.active_client_set
-        return await client_set.client_for(cls, sync=False).get(name, namespace)
+        config = context.active_config
+        return await config.client_for(cls, sync=False).get(name, namespace)
 
     def create(self, namespace: str | None = None) -> Self:
-        client_set = context.active_client_set
-        return client_set.client_for(self.__class__, sync=True).create(self, namespace=namespace)
+        config = context.active_config
+        return config.client_for(self.__class__, sync=True).create(self, namespace=namespace)
 
     async def async_create(self, namespace: str | None = None) -> Self:
-        client_set = context.active_client_set
-        return await client_set.client_for(self.__class__, sync=False).create(
-            self, namespace=namespace
-        )
+        config = context.active_config
+        return await config.client_for(self.__class__, sync=False).create(self, namespace=namespace)
 
     @classmethod
     def delete(cls, name: str, namespace: str | None = None) -> Self:
-        client_set = context.active_client_set
-        return client_set.client_for(cls, sync=True).delete(name, namespace)
+        config = context.active_config
+        return config.client_for(cls, sync=True).delete(name, namespace)
 
     @classmethod
     async def async_delete(cls, name: str, namespace: str | None = None) -> Self:
-        client_set = context.active_client_set
-        return await client_set.client_for(cls, sync=False).delete(name, namespace)
+        config = context.active_config
+        return await config.client_for(cls, sync=False).delete(name, namespace)
 
     def remove(self) -> Self:
-        client_set = context.active_client_set
-        return client_set.client_for(self.__class__, sync=True).remove(self)
+        config = context.active_config
+        return config.client_for(self.__class__, sync=True).remove(self)
 
     async def async_remove(self) -> Self:
-        client_set = context.active_client_set
-        return await client_set.client_for(self.__class__, sync=False).remove(self)
+        config = context.active_config
+        return await config.client_for(self.__class__, sync=False).remove(self)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,117 @@
 # cloudcoil
 
-Cloud native development tools
+Cloud native made easy with Python
+
+### PyPI stats
+
+[![PyPI](https://img.shields.io/pypi/v/cloudcoil.svg)](https://pypi.python.org/pypi/cloudcoil)
+[![Versions](https://img.shields.io/pypi/pyversions/cloudcoil.svg)](https://github.com/cloudcoil/cloudcoil)
+
+[![Downloads](https://static.pepy.tech/badge/cloudcoil)](https://pepy.tech/project/cloudcoil)
+[![Downloads/month](https://static.pepy.tech/badge/cloudcoil/month)](https://pepy.tech/project/cloudcoil)
+[![Downloads/week](https://static.pepy.tech/badge/cloudcoil/week)](https://pepy.tech/project/cloudcoil)
+
+### Repo information
+
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/license/apache-2-0/)
+[![CI](https://github.com/cloudcoil/cloudcoil/actions/workflows/ci.yml/badge.svg)](https://github.com/cloudcoil/cloudcoil/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/cloudcoil/cloudcoil/branch/main/graph/badge.svg)](https://codecov.io/gh/cloudcoil/cloudcoil)
 
 ## Installation
 
 ```bash
-pip install cloudcoil
+# Minimal dependencies
+# pydantic, httpx and pyyaml
+uv add cloudcoil
 ```
 
-## Usage
+## Quick Start
 
 ```python
-import cloudcoil
+# Config is the core way to interact with your Kubernetes API Server
+from cloudcoil.client import Config
+from cloudcoil.client import errors
+# All default kubernetes types are neatly arranged
+# with appropriate apiversions as module paths
+from cloudcoil.kinds.apps import v1 as apps_v1
+from cloudcoil.kinds.core import v1 as core_v1
 
-# Add usage examples here
+
+# Uses the default config based on KUBECONFIG
+# Feels just as natural as kubectl
+# But comes with full pydantic validation
+kubernetes_service = core_v1.Service.get("kubernetes")
+
+# You can create temporary config contexts
+# This is similar to doing kubens kube-system
+with Config(namespace="kube-system"):
+    # This searches for deployments in the kube-system namespace
+    core_dns_deployment = apps_v1.Deployment.get("core-dns")
+    # Also comes with async client out of the box!
+    kube_dns_service = await core_v1.Service.async_get("kube-dns")
+
+# Create new objects with generate name easily
+test_namespace = core_v1.Namespace(metadata=dict(generate_name="test-")).create()
+
+# We can access the output from the APIServer from the create method
+# Switch to the new namespace
+with Config(namespace=test_namespace.metadata.name):
+    try:
+        core_dns_deployment = apps_v1.Deployment.get("core-dns")
+    except errors.ResourceNotFound:
+        pass
+
+# Finally you can remove the namespace
+# And also inspect the output to ensure it is terminating
+test_namespace.remove().status.phase == "Terminating"
+# You can also delete it using the name/namespace if you wish
+core_v1.Namespace.delete(name=test_namespace.metadata.name)
 ```
+
+### Testing Integration
+
+cloudcoil includes pytest fixtures to help you test your Kubernetes applications. Install with test dependencies:
+
+```bash
+uv add cloudcoil[test]
+```
+
+The testing integration provides two key fixtures:
+- `test_cluster`: Creates and manages a k3d cluster for testing
+- `test_config`: Provides a Config instance configured for the test cluster
+
+Example usage:
+
+```python
+import pytest
+from cloudcoil.kinds.core import v1 as corev1
+
+@pytest.mark.configure_test_cluster(
+    cluster_name="my-test-cluster",
+    k3d_version="v5.7.5",
+    k8s_version="v1.31.4",
+    remove=True
+)
+def test_my_resources(test_config):
+    with test_config:
+        namespace = corev1.Namespace.get("default")
+        assert namespace.metadata.name == "default"
+```
+
+#### Test Cluster Configuration
+
+The `configure_test_cluster` mark accepts these arguments:
+
+- `cluster_name`: Name of the test cluster (default: auto-generated)
+- `k3d_version`: Version of k3d to use (default: v5.7.5)
+- `k8s_version`: Kubernetes version to use (default: v1.31.4)
+- `k8s_image`: Custom k3s image (default: rancher/k3s:{k8s_version}-k3s1)
+- `remove`: Whether to remove the cluster after tests (default: True)
+
+## Documentation
+
+For full documentation, please visit [cloudcoil.github.io/cloudcoil](https://cloudcoil.github.io/cloudcoil)
+
+## License
+
+This project is licensed under the Apache License, Version 2.0 - see the [LICENSE](LICENSE) file for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
     "typing_extensions>=4.0.0; python_version <= '3.10'",
 ]
 keywords = ["cloud-native", "kubernetes", "pydantic", "python", "async"]
+[project.optional-dependencies]
+test = ["pytest"]
+
 
 [project.urls]
 Homepage = "https://github.com/cloudcoil/cloudcoil"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-"""Tests for clientset"""
+"""Tests for config"""
 
 import os
 from unittest.mock import patch
@@ -6,8 +6,8 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from cloudcoil.client._client_set import (
-    ClientSet,
+from cloudcoil.client._config import (
+    Config,
 )
 
 
@@ -73,7 +73,7 @@ def test_kubeconfig_initialization(kubeconfig_content, expected, tmp_path):
     kubeconfig.write_text(yaml.dump(kubeconfig_content))
 
     with patch.dict(os.environ, {"KUBECONFIG": str(kubeconfig)}):
-        client = ClientSet()
+        client = Config()
         assert client.server == expected["server"]
         assert client.namespace == expected["namespace"]
         if "token" in expected:
@@ -97,7 +97,7 @@ def test_direct_parameter_initialization(
     params,
     expected,
 ):
-    client = ClientSet(**params)
+    client = Config(**params)
     assert client.server == expected["server"]
     assert client.namespace == expected["namespace"]
     assert client.token == expected["token"]
@@ -122,7 +122,7 @@ def test_invalid_kubeconfig(kubeconfig_content, tmp_path):
 
     with patch.dict(os.environ, {"KUBECONFIG": str(kubeconfig)}):
         with pytest.raises(ValueError):
-            ClientSet()
+            Config()
 
 
 def test_incluster_initialization(tmp_path):
@@ -135,12 +135,12 @@ def test_incluster_initialization(tmp_path):
     namespace_path.write_text("test-namespace")
 
     with (
-        patch("cloudcoil.client._client_set.INCLUSTER_TOKEN_PATH", token_path),
-        patch("cloudcoil.client._client_set.INCLUSTER_CERT_PATH", ca_path),
-        patch("cloudcoil.client._client_set.DEFAULT_KUBECONFIG", tmp_path / "dne"),
-        patch("cloudcoil.client._client_set.INCLUSTER_NAMESPACE_PATH", namespace_path),
+        patch("cloudcoil.client._config.INCLUSTER_TOKEN_PATH", token_path),
+        patch("cloudcoil.client._config.INCLUSTER_CERT_PATH", ca_path),
+        patch("cloudcoil.client._config.DEFAULT_KUBECONFIG", tmp_path / "dne"),
+        patch("cloudcoil.client._config.INCLUSTER_NAMESPACE_PATH", namespace_path),
     ):
-        client = ClientSet()
+        client = Config()
         assert client.server == "https://kubernetes.default.svc"
         assert client.namespace == "test-namespace"
         assert client.token == "test-token"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -7,8 +7,8 @@ from cloudcoil.kinds.core import v1 as corev1
 
 
 @pytest.mark.configure_test_cluster(cluster_name="test-cloudcoil-v1.31", remove=False)
-def test_e2e(test_client_set):
-    with test_client_set:
+def test_e2e(test_config):
+    with test_config:
         assert corev1.Service.get("kubernetes", "default").metadata.name == "kubernetes"
         output = corev1.Namespace(metadata=ObjectMeta(generate_name="test-")).create()
         name = output.metadata.name
@@ -20,8 +20,8 @@ def test_e2e(test_client_set):
 @pytest.mark.configure_test_cluster(
     cluster_name="test-cloudcoil-v1.30", remove=False, version="v1.30.8"
 )
-async def test_async_e2e(test_client_set):
-    with test_client_set:
+async def test_async_e2e(test_config):
+    with test_config:
         assert (
             await corev1.Service.async_get("kubernetes", "default")
         ).metadata.name == "kubernetes"

--- a/uv.lock
+++ b/uv.lock
@@ -260,6 +260,11 @@ dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "datamodel-code-generator", extra = ["http"] },
@@ -286,6 +291,7 @@ dev = [
 requires-dist = [
     { name = "httpx" },
     { name = "pydantic", specifier = ">2.0" },
+    { name = "pytest", marker = "extra == 'test'" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.0" },
 ]


### PR DESCRIPTION
This pull request includes several changes aimed at renaming the `ClientSet` class to `Config` and updating related documentation and tests. Additionally, it introduces new testing integration features for Kubernetes applications.

### Renaming `ClientSet` to `Config`:
* `cloudcoil/client/_client_set.py` renamed to `cloudcoil/client/_config.py` and updated the class name from `ClientSet` to `Config`.
* Updated all references to `ClientSet` in various files to `Config` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R47) [[2]](diffhunk://#diff-f6fd8eb2539c3388dfa73979bd7f2fda0a8a859179cc45b9f18126eff46f40dcL15-R15) [[3]](diffhunk://#diff-4057ef0fe8860290f3edae2ccc8c19ded5c3e67bdebbe978ef5a210be18b0a53L2-R5) [[4]](diffhunk://#diff-b49b925f0b16d47f8eb4e2bdb20629e2bccfcc5bfc6be743dd29bbf85f95f09fL5-R36) [[5]](diffhunk://#diff-87a7c23e2c8e571f89d57831b737bc1cd7f68b0bd85f7f520f925b57554e26d1L40-R72).

### Documentation Updates:
* Updated `README.md` to reflect the renaming of `ClientSet` to `Config` and added a new section on testing integration with pytest fixtures.
* Created `docs/index.md` to include installation instructions, quick start, and testing integration examples.

### Testing Integration:
* Added pytest fixtures for testing Kubernetes applications, including `test_cluster` and `test_config`.
* Updated `pyproject.toml` to include optional test dependencies.

### Test File Updates:
* Renamed `tests/test_clientset.py` to `tests/test_config.py` and updated tests to use `Config` instead of `ClientSet`.

### Makefile Update:
* Modified `Makefile` to remove and copy `README.md` to `docs/index.md` during the `docs-serve` task.