### PR TITLE
Add delete options, create options and appropriate user agent

### DIFF
--- a/cloudcoil/__init__.py
+++ b/cloudcoil/__init__.py
@@ -1,6 +1,3 @@
-from importlib.metadata import version
+from ._version import __version__
 
-try:
-    __version__ = version("cloudcoil")
-except ImportError:
-    __version__ = "0.0.0"
+__all__ = ["__version__"]

--- a/cloudcoil/_version.py
+++ b/cloudcoil/_version.py
@@ -1,0 +1,6 @@
+from importlib.metadata import version
+
+try:
+    __version__ = version("cloudcoil")
+except ImportError:
+    __version__ = "0.0.0"

--- a/cloudcoil/client/_resource.py
+++ b/cloudcoil/client/_resource.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any
+from typing import Any, Literal
 
 from cloudcoil.apimachinery import ListMeta, ObjectMeta
 
@@ -54,19 +54,65 @@ class Resource(BaseResource):
         return await config.client_for(self.__class__, sync=False).create(self, namespace=namespace)
 
     @classmethod
-    def delete(cls, name: str, namespace: str | None = None) -> Self:
+    def delete(
+        cls,
+        name: str,
+        namespace: str | None = None,
+        dry_run: bool = True,
+        propagation_policy: Literal["orphan", "background", "foreground"] | None = None,
+        grace_period_seconds: int | None = None,
+    ) -> Self:
         config = context.active_config
-        return config.client_for(cls, sync=True).delete(name, namespace)
+        return config.client_for(cls, sync=True).delete(
+            name,
+            namespace,
+            dry_run=dry_run,
+            propagation_policy=propagation_policy,
+            grace_period_seconds=grace_period_seconds,
+        )
 
     @classmethod
-    async def async_delete(cls, name: str, namespace: str | None = None) -> Self:
+    async def async_delete(
+        cls,
+        name: str,
+        namespace: str | None = None,
+        dry_run: bool = True,
+        propagation_policy: Literal["orphan", "background", "foreground"] | None = None,
+        grace_period_seconds: int | None = None,
+    ) -> Self:
         config = context.active_config
-        return await config.client_for(cls, sync=False).delete(name, namespace)
+        return await config.client_for(cls, sync=False).delete(
+            name,
+            namespace,
+            dry_run=dry_run,
+            propagation_policy=propagation_policy,
+            grace_period_seconds=grace_period_seconds,
+        )
 
-    def remove(self) -> Self:
+    def remove(
+        self,
+        dry_run: bool = True,
+        propagation_policy: Literal["orphan", "background", "foreground"] | None = None,
+        grace_period_seconds: int | None = None,
+    ) -> Self:
         config = context.active_config
-        return config.client_for(self.__class__, sync=True).remove(self)
+        return config.client_for(self.__class__, sync=True).remove(
+            self,
+            dry_run=dry_run,
+            propagation_policy=propagation_policy,
+            grace_period_seconds=grace_period_seconds,
+        )
 
-    async def async_remove(self) -> Self:
+    async def async_remove(
+        self,
+        dry_run: bool = True,
+        propagation_policy: Literal["orphan", "background", "foreground"] | None = None,
+        grace_period_seconds: int | None = None,
+    ) -> Self:
         config = context.active_config
-        return await config.client_for(self.__class__, sync=False).remove(self)
+        return await config.client_for(self.__class__, sync=False).remove(
+            self,
+            dry_run=dry_run,
+            propagation_policy=propagation_policy,
+            grace_period_seconds=grace_period_seconds,
+        )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -13,8 +13,8 @@ def test_e2e(test_config):
         output = corev1.Namespace(metadata=ObjectMeta(generate_name="test-")).create()
         name = output.metadata.name
         assert corev1.Namespace.get(name).metadata.name == name
-        assert output.remove().metadata.name == name
-        assert corev1.Namespace.delete(name).status.phase == "Terminating"
+        assert output.remove(dry_run=True).metadata.name == name
+        assert corev1.Namespace.delete(name, grace_period_seconds=0).status.phase == "Terminating"
 
 
 @pytest.mark.configure_test_cluster(
@@ -28,5 +28,7 @@ async def test_async_e2e(test_config):
         output = await corev1.Namespace(metadata=ObjectMeta(generate_name="test-")).async_create()
         name = output.metadata.name
         assert (await corev1.Namespace.async_get(name)).metadata.name == name
-        assert (await output.async_remove()).metadata.name == name
-        assert (await corev1.Namespace.async_delete(name)).status.phase == "Terminating"
+        assert (await output.async_remove(dry_run=True)).metadata.name == name
+        assert (
+            await corev1.Namespace.async_delete(name, grace_period_seconds=0)
+        ).status.phase == "Terminating"


### PR DESCRIPTION
This pull request includes several changes to the `cloudcoil` package, focusing on enhancing version management, adding new parameters to API client methods, and improving the configuration setup. The most important changes include moving version management to a dedicated module, adding support for `dry_run` and other parameters in API client methods, and updating headers in the configuration to include a custom User-Agent.

### Version Management:
* [`cloudcoil/__init__.py`](diffhunk://#diff-c886b1bf767fa04729e1cc738faf49577bf1efcd100988407779140db6bfaa63L1-R3): Moved version management to a dedicated `_version` module and updated the `__all__` list.
* [`cloudcoil/_version.py`](diffhunk://#diff-1b2ca1a3a27fddc82d2d87d3f97fe1e56ebd4fe6d5ed51bdecbbf50d83509e7cR1-R6): Added a new module to handle version retrieval using `importlib.metadata`.

### API Client Enhancements:
* [`cloudcoil/client/_api_client.py`](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066L72-R122): Added `dry_run`, `propagation_policy`, and `grace_period_seconds` parameters to `create`, `delete`, and `remove` methods for both synchronous and asynchronous clients. [[1]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066L72-R122) [[2]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066L113-R194)

### Configuration Improvements:
* [`cloudcoil/client/_config.py`](diffhunk://#diff-0794500b70c79f233e6f3cb70a9dec87baf56a0626947b46653c915d034dd472L125-R133): Added a custom User-Agent header to the HTTP client configuration, including version and platform information.

### Resource Management:
* [`cloudcoil/client/_resource.py`](diffhunk://#diff-87a7c23e2c8e571f89d57831b737bc1cd7f68b0bd85f7f520f925b57554e26d1L57-R118): Updated `delete`, `remove`, and their asynchronous counterparts to support `dry_run`, `propagation_policy`, and `grace_period_seconds` parameters.

### Test Updates:
* [`tests/test_e2e.py`](diffhunk://#diff-ed3b8af48cd21dc1ac735b839d89b172a6f45569c324af70a2bdb4f60e5fbcddL16-R17): Modified end-to-end tests to use the new `dry_run` and `grace_period_seconds` parameters in `remove` and `delete` methods. [[1]](diffhunk://#diff-ed3b8af48cd21dc1ac735b839d89b172a6f45569c324af70a2bdb4f60e5fbcddL16-R17) [[2]](diffhunk://#diff-ed3b8af48cd21dc1ac735b839d89b172a6f45569c324af70a2bdb4f60e5fbcddL31-R34)