### PR TITLE
Add a mypy plugin and discover registered schemes dynamically

### DIFF
--- a/cloudcoil/__init__.py
+++ b/cloudcoil/__init__.py
@@ -1,3 +1,4 @@
+from ._scheme import scheme
 from ._version import __version__
 
-__all__ = ["__version__"]
+__all__ = ["__version__", "scheme"]

--- a/cloudcoil/_scheme.py
+++ b/cloudcoil/_scheme.py
@@ -11,25 +11,33 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import Self
 
+import sys
+
 import yaml
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
+
 
 from cloudcoil.client._resource import GVK, Resource
 
 
-class Scheme:
-    default_packages = ["cloudcoil.kinds"]
-
+class _Scheme:
     def __init__(self):
         self._registry = {}
+        self._registered_modules = set()
 
-    def register(self, kind: Type[Resource]) -> None:
+    def _register(self, kind: Type[Resource]) -> None:
         self._registry[kind.gvk()] = kind
+        self._registry[kind.gvk().model_copy(update={"api_version": ""})] = kind
 
-    def register_all(self, kinds: list[Type[Resource]]) -> None:
+    def _register_all(self, kinds: list[Type[Resource]]) -> None:
         for kind in kinds:
-            self.register(kind)
+            self._register(kind)
 
-    def discover(self, module: str | ModuleType) -> None:
+    def _discover(self, module: str | ModuleType) -> None:
         # Uses pkgutil to discover all modules in module_path recursively
         # and imports them
         # Then it looks for all classes that are subclasses of Resource
@@ -41,7 +49,8 @@ class Scheme:
                 for _, obj in inspect.getmembers(module):
                     # Check if object is a class and subclasses base_class
                     if inspect.isclass(obj) and issubclass(obj, Resource) and obj != Resource:
-                        self.register(obj)
+                        self._registered_modules.add(module_name)
+                        self._register(obj)
             except Exception as e:
                 print(f"Error importing module {module_name}: {e}")
 
@@ -54,7 +63,7 @@ class Scheme:
         for _, module_name, _ in pkgutil.walk_packages(package.__path__, package.__name__ + "."):
             import_and_check_module(module_name)
 
-    def get(self, gvk: GVK) -> Type[Resource]:
+    def _get(self, gvk: GVK) -> Type[Resource]:
         if gvk not in self._registry:
             raise ValueError(f"Resource kind '{gvk}' not registered")
         return self._registry[gvk]
@@ -71,18 +80,22 @@ class Scheme:
         resource = Resource.model_validate(obj)
         if not resource.api_version or not resource.kind:
             raise ValueError("Missing apiVersion or kind")
-        kind = self.get_kind(resource.api_version, resource.kind)
+        kind = self.get(resource.api_version, resource.kind)
         return kind.model_validate(obj)
 
-    def get_kind(self, api_version: str, kind: str) -> Type[Resource]:
+    def get(self, kind: str, api_version: str = "") -> Type[Resource]:
         return self._registry[GVK(api_version=api_version, kind=kind)]
 
     def parse_file(self, path: str | Path) -> list[Resource] | Resource:
         return self.parse(yaml.safe_load(Path(path).read_text()))
 
     @classmethod
-    def get_default(cls: Type[Self]) -> Self:
+    def _get_default(cls: Type[Self]) -> Self:
+        discovered_kinds = entry_points(group="cloudcoil_kinds")
         output = cls()
-        for package in cls.default_packages:
-            output.discover(package)
+        for discovered_kind in discovered_kinds:
+            output._discover(discovered_kind.load())
         return output
+
+
+scheme = _Scheme._get_default()

--- a/cloudcoil/mypy.py
+++ b/cloudcoil/mypy.py
@@ -1,0 +1,80 @@
+from typing import Callable, Optional
+
+import mypy
+from mypy.nodes import (
+    Expression,
+    StrExpr,
+    TypeInfo,
+)
+from mypy.plugin import MethodContext, Plugin
+from mypy.types import Instance, TypeType
+from mypy.types import Type as MypyType
+
+from cloudcoil import scheme
+
+
+class SchemePlugin(Plugin):
+    def __init__(self, options):
+        super().__init__(options)
+
+    def get_method_hook(self, fullname: str) -> Optional[Callable[[MethodContext], MypyType]]:
+        if fullname == "cloudcoil._scheme._Scheme.get":
+            return self._analyze_get
+        return None
+
+    def _extract_str_literal(self, expr: Expression) -> Optional[str]:
+        """Extract string literal value if expression is a string literal."""
+        if isinstance(expr, StrExpr):
+            return expr.value
+        return None
+
+    def get_additional_deps(self, file: mypy.nodes.MypyFile):
+        # This is a hack to make sure that mypy knows about all registered modules
+        if file.fullname == "cloudcoil._scheme":
+            return [(10, module_name, -1) for module_name in scheme._registered_modules]
+        return []
+
+    def _analyze_get(self, context: MethodContext) -> MypyType:
+        if not context.args:
+            context.api.fail("Scheme.get requires at least one argument", context.context)
+            return context.default_return_type
+
+        # Find the kind and api_version arguments based on position or name
+        kind_arg = None
+        api_version_arg = None
+
+        for arg_name, arg_expr in zip(context.arg_names, context.args, strict=False):
+            if arg_name == "kind":
+                kind_arg = arg_expr[0]
+            elif arg_name == "api_version":
+                api_version_arg = arg_expr[0]
+
+        # If not found by name, try positional
+        if kind_arg is None and context.args:
+            kind_arg = context.args[0][0]
+        if api_version_arg is None and len(context.args) > 1:
+            api_version_arg = context.args[1][0]
+
+        if not kind_arg:
+            return context.default_return_type
+        kind = self._extract_str_literal(kind_arg)
+        api_version = self._extract_str_literal(api_version_arg) if api_version_arg else None
+        api_version = api_version or ""
+        if not kind:
+            return context.default_return_type
+        cls = scheme.get(api_version=api_version, kind=kind)
+        qualname = f"{cls.__module__}.{cls.__qualname__}"
+        # Lookup the fully qualified name to get the TypeInfo
+        # This is a bit of a hack as we are able to lookup the TypeInfo
+        # based on the fully qualified name because we are loading
+        # the module in the get_additional_deps method
+        symbol = self.lookup_fully_qualified(qualname)
+        if not symbol or not symbol.node:
+            return context.default_return_type
+        if not isinstance(symbol.node, TypeInfo):
+            return context.default_return_type
+        return TypeType(Instance(symbol.node, []))
+
+
+def plugin(_: str):
+    return SchemePlugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,11 +75,14 @@ dev = [
 ]
 
 [tool.mypy]
-plugins = ['pydantic.mypy']
+plugins = ['pydantic.mypy', 'cloudcoil.mypy']
 
 # Add the pytest plugin
 [project.entry-points.pytest11]
 cloudcoil = "cloudcoil._testing.plugin"
+
+[project.entry-points.cloudcoil_kinds]
+default = "cloudcoil.kinds"
 
 [tool.coverage.run]
 omit = ["cloudcoil/kinds/**"]


### PR DESCRIPTION
This allows cloudcoil to dynamically add support for new kinds via an entrypoint hook for scheme.

This allows other cloudcoil extensions to register with a common scheme instance.

We also have a mypy plugin that can correctly deduce the output type based on kind and api-verison.