### PR TITLE
Add more comprehensive support for k8s version and add support for kind based tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
 jobs:
-  test:
+  test-python:
     strategy:
       fail-fast: false
       matrix:
@@ -39,7 +39,6 @@ jobs:
         run: make -j8 lint test
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -50,4 +49,75 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-  
+
+  test-k8s:
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: ["1-29", "1-30", "1-31", "1-32"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v4
+        with:
+          python-version: '3.13'
+          enable-cache: true
+          cache-dependency-glob: "**/uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --extra "kubernetes-${{ matrix.k8s-version }}" --dev
+
+      - name: Run Checks
+        run: make -j8 lint test
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: cloudcoil/cloudcoil
+    
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  test-provider:
+    strategy:
+      fail-fast: false
+      matrix:
+        cluster-provider: [k3d, kind]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v4
+        with:
+          python-version: '3.13'
+          enable-cache: true
+          cache-dependency-glob: "**/uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --extra all --dev
+
+      - name: Run Checks
+        run: make -j8 lint test
+        env:
+          CLUSTER_PROVIDER: ${{ matrix.cluster-provider }}
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: cloudcoil/cloudcoil
+    
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - 🧪 **Testing Ready** - Built-in pytest fixtures for K8s integration tests
 - 📦 **Zero Config** - Works with your existing kubeconfig
 
+
 ## 🔧 Installation
 
 Using [uv](https://github.com/astral-sh/uv) (recommended):
@@ -26,9 +27,10 @@ Using [uv](https://github.com/astral-sh/uv) (recommended):
 uv add cloudcoil[kubernetes]
 
 # Install with specific Kubernetes version compatibility
+uv add cloudcoil[kubernetes-1-29]
 uv add cloudcoil[kubernetes-1-30]
-# or 
 uv add cloudcoil[kubernetes-1-31]
+uv add cloudcoil[kubernetes-1-32]
 ```
 
 Using pip:

--- a/cloudcoil/_testing/clusters.py
+++ b/cloudcoil/_testing/clusters.py
@@ -1,0 +1,170 @@
+import platform
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+import httpx
+
+DEFAULT_K3D_VERSION = "v5.7.5"
+DEFAULT_K8S_VERSION = "v1.31.4"
+DEFAULT_KIND_VERSION = "v0.20.0"
+
+
+@runtime_checkable
+class K8sClusterProvider(Protocol):
+    def create_cluster(self) -> None: ...
+    def get_kubeconfig(self) -> str: ...
+    def remove_cluster(self) -> None: ...
+
+
+class BaseCluster:
+    def __init__(self, cluster_name: str, remove: bool):
+        self.cluster_name = cluster_name
+        self.remove = remove
+
+    def _compute_system_machine(self) -> tuple[str, str]:
+        system = platform.system().lower()
+        machine = platform.machine().lower()
+        if machine == "x86_64":
+            machine = "amd64"
+        elif machine == "aarch64":
+            machine = "arm64"
+        return system, machine
+
+    def _download_binary(self, url: str, binary_path: Path) -> str:
+        if not binary_path.exists():
+            binary_path.parent.mkdir(parents=True, exist_ok=True)
+            response = httpx.get(url, follow_redirects=True)
+            with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+                tmp_file.write(response.content)
+                tmp_path = Path(tmp_file.name)
+            tmp_path.chmod(0o755)
+            try:
+                tmp_path.rename(binary_path)
+            except OSError:
+                if not binary_path.exists():
+                    shutil.move(str(tmp_path), str(binary_path))
+                else:
+                    tmp_path.unlink()
+        return str(binary_path)
+
+
+class K3DCluster(BaseCluster):
+    def __init__(
+        self,
+        cluster_name: str,
+        remove: bool = True,
+        k3d_version: str | None = DEFAULT_K3D_VERSION,
+        k8s_version: str | None = DEFAULT_K8S_VERSION,
+        k8s_image: str | None = None,
+    ):
+        super().__init__(cluster_name, remove)
+        self.k3d_version = k3d_version or DEFAULT_K3D_VERSION
+        self.k8s_version = k8s_version or DEFAULT_K8S_VERSION
+        self.k8s_image = k8s_image or f"rancher/k3s:{self.k8s_version}-k3s1"
+        self.binary_path = Path.home() / ".cache" / "cloudcoil" / "k3d" / self.k3d_version / "k3d"
+        system, machine = self._compute_system_machine()
+        url = f"https://github.com/k3d-io/k3d/releases/download/{self.k3d_version}/k3d-{system}-{machine}"
+        self.binary = self._download_binary(url, self.binary_path)
+
+    def create_cluster(self) -> None:
+        try:
+            subprocess.run(
+                [self.binary, "cluster", "get", self.cluster_name],
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError:
+            command = [
+                self.binary,
+                "cluster",
+                "create",
+                self.cluster_name,
+                "--wait",
+                "--kubeconfig-update-default=false",
+                f"--image={self.k8s_image}",
+            ]
+            subprocess.run(command, check=True)
+
+    def get_kubeconfig(self) -> str:
+        kubeconfig_file = tempfile.NamedTemporaryFile(delete=False)
+        subprocess.run(
+            [self.binary, "kubeconfig", "get", self.cluster_name],
+            check=True,
+            stdout=kubeconfig_file,
+        )
+        kubeconfig_file.close()
+        return kubeconfig_file.name
+
+    def remove_cluster(self) -> None:
+        subprocess.run([self.binary, "cluster", "delete", self.cluster_name], check=True)
+
+
+class KindCluster(BaseCluster):
+    def __init__(
+        self,
+        cluster_name: str,
+        remove: bool = True,
+        kind_version: str | None = None,
+        k8s_version: str | None = None,
+        k8s_image: str | None = None,
+    ):
+        super().__init__(cluster_name, remove)
+        self.kind_version = kind_version or DEFAULT_KIND_VERSION
+        self.k8s_version = k8s_version or DEFAULT_K8S_VERSION
+        self.k8s_image = k8s_image
+        self.binary_path = (
+            Path.home() / ".cache" / "cloudcoil" / "kind" / self.kind_version / "kind"
+        )
+        system, machine = self._compute_system_machine()
+        url = f"https://kind.sigs.k8s.io/dl/{self.kind_version}/kind-{system}-{machine}"
+        self.binary = self._download_binary(url, self.binary_path)
+        self._kubeconfig = tempfile.NamedTemporaryFile(delete=False).name
+
+    def create_cluster(self) -> None:
+        clusters = (
+            subprocess.run(
+                [self.binary, "get", "clusters"],
+                check=True,
+                capture_output=True,
+            )
+            .stdout.decode()
+            .split("\n")
+        )
+        if self.cluster_name not in clusters:
+            command = [
+                self.binary,
+                "create",
+                "cluster",
+                f"--name={self.cluster_name}",
+                f"--kubeconfig={self._kubeconfig}",
+                "--wait=5m",
+            ]
+            if self.k8s_image:
+                command.append(f"--image={self.k8s_image}")
+            subprocess.run(command, check=True)
+        else:
+            subprocess.run(
+                [
+                    self.binary,
+                    "export",
+                    "kubeconfig",
+                    f"--name={self.cluster_name}",
+                    f"--kubeconfig={self._kubeconfig}",
+                ],
+                check=True,
+            )
+
+    def get_kubeconfig(self) -> str:
+        return self._kubeconfig
+
+    def remove_cluster(self) -> None:
+        subprocess.run(
+            [self.binary, "delete", "cluster", f"--name={self.cluster_name}"], check=True
+        )
+        try:
+            Path(self._kubeconfig).unlink()
+        except FileNotFoundError:
+            pass

--- a/cloudcoil/_testing/plugin.py
+++ b/cloudcoil/_testing/plugin.py
@@ -1,98 +1,54 @@
 import random
-import shutil
 import string
-import tempfile
 
 try:
     import pytest
 except ImportError:
     raise ImportError("Please install pytest to enable the testing fixtures")
-import platform
-import subprocess
-from pathlib import Path
 
-import httpx
 
+from cloudcoil._testing.clusters import (
+    K3DCluster,
+    KindCluster,
+)
 from cloudcoil.client import Config
-
-DEFAULT_K3D_VERSION = "v5.7.5"
-DEFAULT_K8S_VERSION = "v1.31.4"
 
 
 @pytest.fixture
 def test_cluster(request):
     if "configure_test_cluster" in request.keywords:
-        paramaters = dict(request.keywords["configure_test_cluster"].kwargs)
+        parameters = dict(request.keywords["configure_test_cluster"].kwargs)
 
-    k3d_version = paramaters.get("k3d_version", DEFAULT_K3D_VERSION)
-    k8s_version = paramaters.get("k8s_version", DEFAULT_K8S_VERSION)
-    k8s_image = paramaters.get("k8s_image", f"rancher/k3s:{k8s_version}-k3s1")
-    remove = paramaters.get("remove", True)
-    cluster_name = paramaters.get(
-        "cluster_name", f"test-cluster-{random.choices(string.ascii_lowercase, k=5)}"
+    provider = parameters.get("provider", "kind")
+    remove = parameters.get("remove", True)
+    cluster_name = parameters.get(
+        "cluster_name", f"test-cluster-{''.join(random.choices(string.ascii_lowercase, k=5))}"
     )
-    k3d_binary_path = Path.home() / ".cache" / "cloudcoil" / "k3d" / k3d_version / "k3d"
-    if not k3d_binary_path.exists():
-        k3d_binary_path.parent.mkdir(parents=True, exist_ok=True)
-        system = platform.system().lower()
-        machine = platform.machine().lower()
-        if machine == "x86_64":
-            machine = "amd64"
-        elif machine == "aarch64":
-            machine = "arm64"
 
-        url = (
-            f"https://github.com/k3d-io/k3d/releases/download/{k3d_version}/k3d-{system}-{machine}"
+    if provider == "k3d":
+        provider = K3DCluster(
+            cluster_name,
+            remove,
+            parameters.get("k3d_version"),
+            parameters.get("k8s_version"),
+            parameters.get("k8s_image"),
         )
-        response = httpx.get(url, follow_redirects=True)
-        response.raise_for_status()
+    elif provider == "kind":
+        provider = KindCluster(
+            cluster_name,
+            remove,
+            parameters.get("kind_version"),
+            parameters.get("k8s_version"),
+            parameters.get("k8s_image"),
+        )
+    else:
+        raise ValueError(f"Unsupported cluster provider: {provider}")
 
-        with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
-            tmp_file.write(response.content)
-            tmp_path = Path(tmp_file.name)
-
-        tmp_path.chmod(0o755)
-        try:
-            tmp_path.rename(k3d_binary_path)
-        except OSError:
-            # In case another process created the file first
-            if not k3d_binary_path.exists():
-                shutil.move(str(tmp_path), str(k3d_binary_path))
-            else:
-                tmp_path.unlink()
-
-    k3d_binary = str(k3d_binary_path)
-    # Create the cluster
-    # check if the cluster already exists
-    try:
-        subprocess.run(
-            [k3d_binary, "cluster", "get", cluster_name],
-            check=True,
-            capture_output=True,
-        )
-    except subprocess.CalledProcessError:
-        subprocess.run(
-            [
-                k3d_binary,
-                "cluster",
-                "create",
-                cluster_name,
-                f"--image={k8s_image}",
-                "--wait",
-                "--kubeconfig-update-default=false",
-            ],
-            check=True,
-        )
-    # fetch the kubeconfig to a temporary path and yield the path
-    with tempfile.NamedTemporaryFile() as kubeconfig_file:
-        subprocess.run(
-            [k3d_binary, "kubeconfig", "get", cluster_name],
-            check=True,
-            stdout=kubeconfig_file,
-        )
-        yield kubeconfig_file.name
+    provider.create_cluster()
+    kubeconfig_path = provider.get_kubeconfig()
+    yield kubeconfig_path
     if remove:
-        subprocess.run([k3d_binary, "cluster", "delete", cluster_name], check=True)
+        provider.remove_cluster()
 
 
 @pytest.fixture

--- a/cloudcoil/resources.py
+++ b/cloudcoil/resources.py
@@ -303,7 +303,7 @@ class ResourceList(BaseResource, Generic[T]):
             resource_list = await resource_list.async_get_next_page()
 
     def __len__(self):
-        return len(self.items) + self.metadata.remaining_item_count
+        return len(self.items) + (self.metadata.remaining_item_count or 0)
 
 
 class _Scheme:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "httpx",
     "pyyaml>=6.0.2",
     "typing_extensions>=4.0.0; python_version <= '3.10'",
+    "cloudcoil-models-kubernetes>=1.29.12.0",
 ]
 keywords = ["cloud-native", "kubernetes", "pydantic", "python", "async"]
 
@@ -28,8 +29,10 @@ cloudcoil-model-codegen = "cloudcoil.codegen.generator:main"
 test = ["pytest"]
 codegen = ["datamodel-code-generator[http]~=0.26.4", "ruff"]
 kubernetes = ["cloudcoil.models.kubernetes"]
+kubernetes-1-32 = ["cloudcoil.models.kubernetes~=1.32.0"]
 kubernetes-1-31 = ["cloudcoil.models.kubernetes~=1.31.0"]
 kubernetes-1-30 = ["cloudcoil.models.kubernetes~=1.30.0"]
+kubernetes-1-29 = ["cloudcoil.models.kubernetes~=1.29.0"]
 all = ["cloudcoil.models.kubernetes"]
 
 
@@ -106,7 +109,14 @@ omit = [
 only-include = ["cloudcoil"]
 
 [tool.uv]
-conflicts = [[{ extra = "kubernetes-1-30" }, { extra = "kubernetes-1-31" }]]
+conflicts = [
+    [
+        { extra = "kubernetes-1-29" },
+        { extra = "kubernetes-1-30" },
+        { extra = "kubernetes-1-31" },
+        { extra = "kubernetes-1-32" },
+    ],
+]
 
 [[tool.cloudcoil.codegen.models]]
 # Unique name for the models
@@ -120,6 +130,6 @@ generate-py-typed = false
 # Rename the definitions to a more pythonic name
 # This is a list of regex substitutions
 transformations = [
-    { match = "^io\\.k8s\\.apimachinery\\..*\\.(.+)", replace = "apimachinery.\\g<1>"},
+    { match = "^io\\.k8s\\.apimachinery\\..*\\.(.+)", replace = "apimachinery.\\g<1>" },
     { match = "^(.+)$", exclude = true },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -7,8 +7,10 @@ resolution-markers = [
     "python_full_version >= '4.0'",
 ]
 conflicts = [[
+    { package = "cloudcoil", extra = "kubernetes-1-29" },
     { package = "cloudcoil", extra = "kubernetes-1-30" },
     { package = "cloudcoil", extra = "kubernetes-1-31" },
+    { package = "cloudcoil", extra = "kubernetes-1-32" },
 ]]
 
 [[package]]
@@ -22,7 +24,7 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.7.0"
+version = "4.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
@@ -30,9 +32,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/40/318e58f669b1a9e00f5c4453910682e2d9dd594334539c7b7817dabb765f/anyio-4.7.0.tar.gz", hash = "sha256:2f834749c602966b7d456a7567cafcb309f96482b5081d14ac93ccd457f9dd48", size = 177076 }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/73/199a98fc2dae33535d6b8e8e6ec01f8c1d76c9adb096c6b7d64823038cde/anyio-4.8.0.tar.gz", hash = "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a", size = 181126 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/7a/4daaf3b6c08ad7ceffea4634ec206faeff697526421c20f07628c7372156/anyio-4.7.0-py3-none-any.whl", hash = "sha256:ea60c3723ab42ba6fff7e8ccb0488c898ec538ff4df1f1d5e642c3601d07e352", size = 93052 },
+    { url = "https://files.pythonhosted.org/packages/46/eb/e7f063ad1fec6b3178a3cd82d1a3c4de82cccf283fc42746168188e1cdd5/anyio-4.8.0-py3-none-any.whl", hash = "sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a", size = 96041 },
 ]
 
 [[package]]
@@ -72,8 +74,8 @@ dependencies = [
     { name = "packaging" },
     { name = "pathspec" },
     { name = "platformdirs" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/0d/cc2fb42b8c50d80143221515dd7e4766995bd07c56c9a3ed30baf080b6dc/black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875", size = 645813 }
 wheels = [
@@ -171,7 +173,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -183,6 +185,10 @@ name = "cloudcoil"
 version = "0.1.0.dev0"
 source = { editable = "." }
 dependencies = [
+    { name = "cloudcoil-models-kubernetes", version = "1.29.12.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.30.8.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-30' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.31.4.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.32.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra != 'extra-9-cloudcoil-kubernetes-1-31')" },
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -191,22 +197,32 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
-    { name = "cloudcoil-models-kubernetes", version = "1.30.8.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-30' or extra != 'extra-9-cloudcoil-kubernetes-1-31'" },
-    { name = "cloudcoil-models-kubernetes", version = "1.31.4.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31'" },
+    { name = "cloudcoil-models-kubernetes", version = "1.29.12.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.30.8.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-30' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.31.4.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.32.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra != 'extra-9-cloudcoil-kubernetes-1-31')" },
 ]
 codegen = [
     { name = "datamodel-code-generator", extra = ["http"] },
     { name = "ruff" },
 ]
 kubernetes = [
-    { name = "cloudcoil-models-kubernetes", version = "1.30.8.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-30' or extra != 'extra-9-cloudcoil-kubernetes-1-31'" },
-    { name = "cloudcoil-models-kubernetes", version = "1.31.4.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31'" },
+    { name = "cloudcoil-models-kubernetes", version = "1.29.12.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.30.8.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-30' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.31.4.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.32.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra != 'extra-9-cloudcoil-kubernetes-1-31')" },
+]
+kubernetes-1-29 = [
+    { name = "cloudcoil-models-kubernetes", version = "1.29.12.0", source = { registry = "https://pypi.org/simple" } },
 ]
 kubernetes-1-30 = [
-    { name = "cloudcoil-models-kubernetes", version = "1.30.8.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cloudcoil-models-kubernetes", version = "1.30.8.3", source = { registry = "https://pypi.org/simple" } },
 ]
 kubernetes-1-31 = [
-    { name = "cloudcoil-models-kubernetes", version = "1.31.4.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cloudcoil-models-kubernetes", version = "1.31.4.3", source = { registry = "https://pypi.org/simple" } },
+]
+kubernetes-1-32 = [
+    { name = "cloudcoil-models-kubernetes", version = "1.32.0.0", source = { registry = "https://pypi.org/simple" } },
 ]
 test = [
     { name = "pytest" },
@@ -233,10 +249,13 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cloudcoil-models-kubernetes", specifier = ">=1.29.12.0" },
     { name = "cloudcoil-models-kubernetes", marker = "extra == 'all'" },
     { name = "cloudcoil-models-kubernetes", marker = "extra == 'kubernetes'" },
+    { name = "cloudcoil-models-kubernetes", marker = "extra == 'kubernetes-1-29'", specifier = "~=1.29.0" },
     { name = "cloudcoil-models-kubernetes", marker = "extra == 'kubernetes-1-30'", specifier = "~=1.30.0" },
     { name = "cloudcoil-models-kubernetes", marker = "extra == 'kubernetes-1-31'", specifier = "~=1.31.0" },
+    { name = "cloudcoil-models-kubernetes", marker = "extra == 'kubernetes-1-32'", specifier = "~=1.32.0" },
     { name = "datamodel-code-generator", extras = ["http"], marker = "extra == 'codegen'", specifier = "~=0.26.4" },
     { name = "httpx" },
     { name = "pydantic", specifier = ">2.0" },
@@ -268,7 +287,7 @@ dev = [
 
 [[package]]
 name = "cloudcoil-models-kubernetes"
-version = "1.30.8.2"
+version = "1.29.12.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '4.0'",
@@ -277,16 +296,16 @@ resolution-markers = [
     "python_full_version >= '4.0'",
 ]
 dependencies = [
-    { name = "cloudcoil" },
+    { name = "cloudcoil", marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/e2/3b4199a41e2e53700f616b7eb5eb7fa8181311904c8c2d49b167bb974ee8/cloudcoil_models_kubernetes-1.30.8.2.tar.gz", hash = "sha256:23302527edc6655a62f104fb0ef2e7deef7206d75014ffa530114044ebe2b242", size = 209061 }
+sdist = { url = "https://files.pythonhosted.org/packages/69/3c/cae8aaf0f97d7889c715d5626105c1b097a4fcd89404f1fe2fa36a5c7724/cloudcoil_models_kubernetes-1.29.12.0.tar.gz", hash = "sha256:f7e651534c28435b770326c60b2d4224c63278a0eb9c36429841d73bc055f3b2", size = 197384 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/65/3b10c57e94da1e16e7af06de6b25ef625da331c3e1ef4ee1778691c73242/cloudcoil_models_kubernetes-1.30.8.2-py3-none-any.whl", hash = "sha256:ad90ef0b1ecad612e23f6aad3f37bca7072e82f89aa96234a6d834a8c3d5ef1a", size = 188887 },
+    { url = "https://files.pythonhosted.org/packages/d5/a7/3706345339817ee208d8be1c9998ec3eb5e316a78eee16aacae09d1b2579/cloudcoil_models_kubernetes-1.29.12.0-py3-none-any.whl", hash = "sha256:780e296c2c00cfb9091ebac1da5c632e9d05b95cabfa1204411463aaf6ff77c2", size = 177362 },
 ]
 
 [[package]]
 name = "cloudcoil-models-kubernetes"
-version = "1.31.4.2"
+version = "1.30.8.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '4.0'",
@@ -295,11 +314,47 @@ resolution-markers = [
     "python_full_version >= '4.0'",
 ]
 dependencies = [
-    { name = "cloudcoil", marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31'" },
+    { name = "cloudcoil", marker = "extra == 'extra-9-cloudcoil-kubernetes-1-30' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/f8/c0cfcaba144cf604fb7ac20b3aae8be0faa1c3e3850888359019026dfd93/cloudcoil_models_kubernetes-1.31.4.2.tar.gz", hash = "sha256:d85b581115e1e6f612bc90d3881b7f6d0244e7169c62dd441b2c53433bd877b7", size = 214656 }
+sdist = { url = "https://files.pythonhosted.org/packages/36/31/27f74aa62df2128b72999dcce5d98d6ad56055b1927b44a7eeb1171ca796/cloudcoil_models_kubernetes-1.30.8.3.tar.gz", hash = "sha256:e65eb7267ca306d74b2c06e5cc7b6a3b1bc3ff953a5704de7c44cca6bb9b168e", size = 209081 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/c8/ea6b0ecc6b8c0174bdd727f61a4bea8086c356a448135b782f85f34b5e46/cloudcoil_models_kubernetes-1.31.4.2-py3-none-any.whl", hash = "sha256:30acace0687aa7397749b19d2a8c9b3ba92129c7d600e65074e9938d90fd7d3c", size = 196758 },
+    { url = "https://files.pythonhosted.org/packages/9b/79/bc3e0a6971edfdb921b833cb8a69489ddd6442068cbbdfca6c26e371569e/cloudcoil_models_kubernetes-1.30.8.3-py3-none-any.whl", hash = "sha256:3b421246aa0db08a89ede19287f1599f9fef1fec5105252b0c11189f27d16137", size = 188892 },
+]
+
+[[package]]
+name = "cloudcoil-models-kubernetes"
+version = "1.31.4.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and python_full_version < '4.0'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+    "python_full_version >= '4.0'",
+]
+dependencies = [
+    { name = "cloudcoil", marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/1c/aa205d980ce73a058be02784aff5194233783531b95f8b7114c15a45dd2d/cloudcoil_models_kubernetes-1.31.4.3.tar.gz", hash = "sha256:0d513f1c2e47f023bff01a94d9897cbd3ca9093dc603dcd1d7ef428968c6ad86", size = 214679 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/aa/4473718fb41c61c28151d75f594cc070e6b04476aa60f3971e7595eddc4b/cloudcoil_models_kubernetes-1.31.4.3-py3-none-any.whl", hash = "sha256:6620c8f4f2daf714c5301631e8fdac424045cf3e19051f68463ac6b77707a18a", size = 196762 },
+]
+
+[[package]]
+name = "cloudcoil-models-kubernetes"
+version = "1.32.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and python_full_version < '4.0'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+    "python_full_version >= '4.0'",
+]
+dependencies = [
+    { name = "cloudcoil", marker = "extra == 'extra-9-cloudcoil-kubernetes-1-32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra != 'extra-9-cloudcoil-kubernetes-1-31')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/5e/20c20c3c29727fb73b0287ea449e9f7d593ce6182847ecbef3e5c28e5a73/cloudcoil_models_kubernetes-1.32.0.0.tar.gz", hash = "sha256:4c32dc6df9ad6e0d2cf2ddcec5c08e1a4216225bc2dd0e34ce72eb213bc7a8ae", size = 212680 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/40/d019bf25f0137ef74b587fbaed6b23e6f191c51cde0f8a602a370918b2d5/cloudcoil_models_kubernetes-1.32.0.0-py3-none-any.whl", hash = "sha256:7bfdfabc0a33464daab4917f477793cacc456ee78f8c57740c81b0817ada0e51", size = 198119 },
 ]
 
 [[package]]
@@ -372,7 +427,7 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "tomli", marker = "python_full_version <= '3.11' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
 ]
 
 [[package]]
@@ -387,9 +442,9 @@ dependencies = [
     { name = "isort" },
     { name = "jinja2" },
     { name = "packaging" },
-    { name = "pydantic", extra = ["email"], marker = "python_full_version < '4.0' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "pydantic", extra = ["email"], marker = "python_full_version < '4.0' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
     { name = "pyyaml" },
-    { name = "toml", marker = "python_full_version < '3.11' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "toml", marker = "python_full_version < '3.11' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d3/4989ef484c41c35f45a16b54ffc25ffb4972d2fefde576a604f1c8c0675d/datamodel_code_generator-0.26.4.tar.gz", hash = "sha256:9881124fec15655a3a635808ea5ded63afb0540c0c402998070ccf60a9dab225", size = 92241 }
 wheels = [
@@ -424,8 +479,8 @@ name = "email-validator"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dnspython", marker = "python_full_version < '4.0' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
-    { name = "idna", marker = "python_full_version < '4.0' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "dnspython", marker = "python_full_version < '4.0' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "idna", marker = "python_full_version < '4.0' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/ce/13508a1ec3f8bb981ae4ca79ea40384becc868bfae97fd1c942bb3a001b1/email_validator-2.2.0.tar.gz", hash = "sha256:cb690f344c617a714f22e66ae771445a1ceb46821152df8e165c5f9a364582b7", size = 48967 }
 wheels = [
@@ -561,17 +616,17 @@ name = "ipython"
 version = "8.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
     { name = "decorator" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
     { name = "jedi" },
     { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (sys_platform == 'win32' and extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "pexpect", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (sys_platform == 'emscripten' and extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (sys_platform == 'emscripten' and extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (sys_platform == 'emscripten' and extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (sys_platform == 'emscripten' and extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (sys_platform == 'emscripten' and extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (sys_platform == 'win32' and extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (sys_platform == 'win32' and extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (sys_platform == 'win32' and extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (sys_platform == 'win32' and extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (sys_platform == 'win32' and extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (sys_platform == 'win32' and extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
     { name = "prompt-toolkit" },
     { name = "pygments" },
     { name = "stack-data" },
     { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/01/35/6f90fdddff7a08b7b715fccbd2427b5212c9525cd043d26fdc45bee0708d/ipython-8.31.0.tar.gz", hash = "sha256:b6a2274606bec6166405ff05e54932ed6e5cfecaca1fc05f2cacde7bb074d70b", size = 5501011 }
 wheels = [
@@ -705,7 +760,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -821,7 +876,7 @@ version = "1.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mypy-extensions" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/eb/2c92d8ea1e684440f54fa49ac5d9a5f19967b7b472a281f419e69a8d228e/mypy-1.14.1.tar.gz", hash = "sha256:7ec88144fe9b510e8475ec2f5f251992690fcf89ccb4500b214b4226abcd32d6", size = 3216051 }
@@ -974,7 +1029,7 @@ wheels = [
 
 [package.optional-dependencies]
 email = [
-    { name = "email-validator", marker = "python_full_version < '4.0' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "email-validator", marker = "python_full_version < '4.0' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
 ]
 
 [[package]]
@@ -1054,11 +1109,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.18.0"
+version = "2.19.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199", size = 4891905 }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/c0/9c9832e5be227c40e1ce774d493065f83a91d6430baa7e372094e9683a45/pygments-2.19.0.tar.gz", hash = "sha256:afc4146269910d4bdfabcd27c24923137a74d562a23a320a41a55ad303e19783", size = 4967733 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513 },
+    { url = "https://files.pythonhosted.org/packages/20/dc/fde3e7ac4d279a331676829af4afafd113b34272393d73f610e8f0329221/pygments-2.19.0-py3-none-any.whl", hash = "sha256:4755e6e64d22161d5b61432c0600c923c5927214e7c956e31c23923c89251a9b", size = 1225305 },
 ]
 
 [[package]]
@@ -1079,12 +1134,12 @@ name = "pytest"
 version = "8.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
 wheels = [
@@ -1297,27 +1352,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.8.5"
+version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/25/5d/4b5403f3e89837decfd54c51bea7f94b7d3fae77e08858603d0e04d7ad17/ruff-0.8.5.tar.gz", hash = "sha256:1098d36f69831f7ff2a1da3e6407d5fbd6dfa2559e4f74ff2d260c5588900317", size = 3454835 }
+sdist = { url = "https://files.pythonhosted.org/packages/da/00/089db7890ea3be5709e3ece6e46408d6f1e876026ec3fd081ee585fef209/ruff-0.8.6.tar.gz", hash = "sha256:dcad24b81b62650b0eb8814f576fc65cfee8674772a6e24c9b747911801eeaa5", size = 3473116 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/f8/03391745a703ce11678eb37c48ae89ec60396ea821e9d0bcea7c8e88fd91/ruff-0.8.5-py3-none-linux_armv6l.whl", hash = "sha256:5ad11a5e3868a73ca1fa4727fe7e33735ea78b416313f4368c504dbeb69c0f88", size = 10626889 },
-    { url = "https://files.pythonhosted.org/packages/55/74/83bb74a44183b904216f3edfb9995b89830c83aaa6ce84627f74da0e0cf8/ruff-0.8.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f69ab37771ea7e0715fead8624ec42996d101269a96e31f4d31be6fc33aa19b7", size = 10398233 },
-    { url = "https://files.pythonhosted.org/packages/e8/7a/a162a4feb3ef85d594527165e366dde09d7a1e534186ff4ba5d127eda850/ruff-0.8.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b5462d7804558ccff9c08fe8cbf6c14b7efe67404316696a2dde48297b1925bb", size = 10001843 },
-    { url = "https://files.pythonhosted.org/packages/e7/9f/5ee5dcd135411402e35b6ec6a8dfdadbd31c5cd1c36a624d356a38d76090/ruff-0.8.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d56de7220a35607f9fe59f8a6d018e14504f7b71d784d980835e20fc0611cd50", size = 10872507 },
-    { url = "https://files.pythonhosted.org/packages/b6/67/db2df2dd4a34b602d7f6ebb1b3744c8157f0d3579973ffc58309c9c272e8/ruff-0.8.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9d99cf80b0429cbebf31cbbf6f24f05a29706f0437c40413d950e67e2d4faca4", size = 10377200 },
-    { url = "https://files.pythonhosted.org/packages/fe/ff/fe3a6a73006bced73e60d171d154a82430f61d97e787f511a24bd6302611/ruff-0.8.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b75ac29715ac60d554a049dbb0ef3b55259076181c3369d79466cb130eb5afd", size = 11433155 },
-    { url = "https://files.pythonhosted.org/packages/e3/95/c1d1a1fe36658c1f3e1b47e1cd5f688b72d5786695b9e621c2c38399a95e/ruff-0.8.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:c9d526a62c9eda211b38463528768fd0ada25dad524cb33c0e99fcff1c67b5dc", size = 12139227 },
-    { url = "https://files.pythonhosted.org/packages/1b/fe/644b70d473a27b5112ac7a3428edcc1ce0db775c301ff11aa146f71886e0/ruff-0.8.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:587c5e95007612c26509f30acc506c874dab4c4abbacd0357400bd1aa799931b", size = 11697941 },
-    { url = "https://files.pythonhosted.org/packages/00/39/4f83e517ec173e16a47c6d102cd22a1aaebe80e1208a1f2e83ab9a0e4134/ruff-0.8.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:622b82bf3429ff0e346835ec213aec0a04d9730480cbffbb6ad9372014e31bbd", size = 12967686 },
-    { url = "https://files.pythonhosted.org/packages/1a/f6/52a2973ff108d74b5da706a573379eea160bece098f7cfa3f35dc4622710/ruff-0.8.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f99be814d77a5dac8a8957104bdd8c359e85c86b0ee0e38dca447cb1095f70fb", size = 11253788 },
-    { url = "https://files.pythonhosted.org/packages/ce/1f/3b30f3c65b1303cb8e268ec3b046b77ab21ed8e26921cfc7e8232aa57f2c/ruff-0.8.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c01c048f9c3385e0fd7822ad0fd519afb282af9cf1778f3580e540629df89725", size = 10860360 },
-    { url = "https://files.pythonhosted.org/packages/a5/a8/2a3ea6bacead963f7aeeba0c61815d9b27b0d638e6a74984aa5cc5d27733/ruff-0.8.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7512e8cb038db7f5db6aae0e24735ff9ea03bb0ed6ae2ce534e9baa23c1dc9ea", size = 10457922 },
-    { url = "https://files.pythonhosted.org/packages/17/47/8f9514b670969aab57c5fc826fb500a16aee8feac1bcf8a91358f153a5ba/ruff-0.8.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:762f113232acd5b768d6b875d16aad6b00082add40ec91c927f0673a8ec4ede8", size = 10958347 },
-    { url = "https://files.pythonhosted.org/packages/0d/d6/78a9af8209ad99541816d74f01ce678fc01ebb3f37dd7ab8966646dcd92b/ruff-0.8.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:03a90200c5dfff49e4c967b405f27fdfa81594cbb7c5ff5609e42d7fe9680da5", size = 11328882 },
-    { url = "https://files.pythonhosted.org/packages/54/77/5c8072ec7afdfdf42c7a4019044486a2b6c85ee73617f8875ec94b977fed/ruff-0.8.5-py3-none-win32.whl", hash = "sha256:8710ffd57bdaa6690cbf6ecff19884b8629ec2a2a2a2f783aa94b1cc795139ed", size = 8802515 },
-    { url = "https://files.pythonhosted.org/packages/bc/b6/47d2b06784de8ae992c45cceb2a30f3f205b3236a629d7ca4c0c134839a2/ruff-0.8.5-py3-none-win_amd64.whl", hash = "sha256:4020d8bf8d3a32325c77af452a9976a9ad6455773bcb94991cf15bd66b347e47", size = 9684231 },
-    { url = "https://files.pythonhosted.org/packages/bf/5e/ffee22bf9f9e4b2669d1f0179ae8804584939fb6502b51f2401e26b1e028/ruff-0.8.5-py3-none-win_arm64.whl", hash = "sha256:134ae019ef13e1b060ab7136e7828a6d83ea727ba123381307eb37c6bd5e01cb", size = 9124741 },
+    { url = "https://files.pythonhosted.org/packages/d7/28/aa07903694637c2fa394a9f4fe93cf861ad8b09f1282fa650ef07ff9fe97/ruff-0.8.6-py3-none-linux_armv6l.whl", hash = "sha256:defed167955d42c68b407e8f2e6f56ba52520e790aba4ca707a9c88619e580e3", size = 10628735 },
+    { url = "https://files.pythonhosted.org/packages/2b/43/827bb1448f1fcb0fb42e9c6edf8fb067ca8244923bf0ddf12b7bf949065c/ruff-0.8.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:54799ca3d67ae5e0b7a7ac234baa657a9c1784b48ec954a094da7c206e0365b1", size = 10386758 },
+    { url = "https://files.pythonhosted.org/packages/df/93/fc852a81c3cd315b14676db3b8327d2bb2d7508649ad60bfdb966d60738d/ruff-0.8.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e88b8f6d901477c41559ba540beeb5a671e14cd29ebd5683903572f4b40a9807", size = 10007808 },
+    { url = "https://files.pythonhosted.org/packages/94/e9/e0ed4af1794335fb280c4fac180f2bf40f6a3b859cae93a5a3ada27325ae/ruff-0.8.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0509e8da430228236a18a677fcdb0c1f102dd26d5520f71f79b094963322ed25", size = 10861031 },
+    { url = "https://files.pythonhosted.org/packages/82/68/da0db02f5ecb2ce912c2bef2aa9fcb8915c31e9bc363969cfaaddbc4c1c2/ruff-0.8.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:91a7ddb221779871cf226100e677b5ea38c2d54e9e2c8ed847450ebbdf99b32d", size = 10388246 },
+    { url = "https://files.pythonhosted.org/packages/ac/1d/b85383db181639019b50eb277c2ee48f9f5168f4f7c287376f2b6e2a6dc2/ruff-0.8.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:248b1fb3f739d01d528cc50b35ee9c4812aa58cc5935998e776bf8ed5b251e75", size = 11424693 },
+    { url = "https://files.pythonhosted.org/packages/ac/b7/30bc78a37648d31bfc7ba7105b108cb9091cd925f249aa533038ebc5a96f/ruff-0.8.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:bc3c083c50390cf69e7e1b5a5a7303898966be973664ec0c4a4acea82c1d4315", size = 12141921 },
+    { url = "https://files.pythonhosted.org/packages/60/b3/ee0a14cf6a1fbd6965b601c88d5625d250b97caf0534181e151504498f86/ruff-0.8.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:52d587092ab8df308635762386f45f4638badb0866355b2b86760f6d3c076188", size = 11692419 },
+    { url = "https://files.pythonhosted.org/packages/ef/d6/c597062b2931ba3e3861e80bd2b147ca12b3370afc3889af46f29209037f/ruff-0.8.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:61323159cf21bc3897674e5adb27cd9e7700bab6b84de40d7be28c3d46dc67cf", size = 12981648 },
+    { url = "https://files.pythonhosted.org/packages/68/84/21f578c2a4144917985f1f4011171aeff94ab18dfa5303ac632da2f9af36/ruff-0.8.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ae4478b1471fc0c44ed52a6fb787e641a2ac58b1c1f91763bafbc2faddc5117", size = 11251801 },
+    { url = "https://files.pythonhosted.org/packages/6c/aa/1ac02537c8edeb13e0955b5db86b5c050a1dcba54f6d49ab567decaa59c1/ruff-0.8.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0c000a471d519b3e6cfc9c6680025d923b4ca140ce3e4612d1a2ef58e11f11fe", size = 10849857 },
+    { url = "https://files.pythonhosted.org/packages/eb/00/020cb222252d833956cb3b07e0e40c9d4b984fbb2dc3923075c8f944497d/ruff-0.8.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:9257aa841e9e8d9b727423086f0fa9a86b6b420fbf4bf9e1465d1250ce8e4d8d", size = 10470852 },
+    { url = "https://files.pythonhosted.org/packages/00/56/e6d6578202a0141cd52299fe5acb38b2d873565f4670c7a5373b637cf58d/ruff-0.8.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:45a56f61b24682f6f6709636949ae8cc82ae229d8d773b4c76c09ec83964a95a", size = 10972997 },
+    { url = "https://files.pythonhosted.org/packages/be/31/dd0db1f4796bda30dea7592f106f3a67a8f00bcd3a50df889fbac58e2786/ruff-0.8.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:496dd38a53aa173481a7d8866bcd6451bd934d06976a2505028a50583e001b76", size = 11317760 },
+    { url = "https://files.pythonhosted.org/packages/d4/70/cfcb693dc294e034c6fed837fa2ec98b27cc97a26db5d049345364f504bf/ruff-0.8.6-py3-none-win32.whl", hash = "sha256:e169ea1b9eae61c99b257dc83b9ee6c76f89042752cb2d83486a7d6e48e8f764", size = 8799729 },
+    { url = "https://files.pythonhosted.org/packages/60/22/ae6bcaa0edc83af42751bd193138bfb7598b2990939d3e40494d6c00698c/ruff-0.8.6-py3-none-win_amd64.whl", hash = "sha256:f1d70bef3d16fdc897ee290d7d20da3cbe4e26349f62e8a0274e7a3f4ce7a905", size = 9673857 },
+    { url = "https://files.pythonhosted.org/packages/91/f8/3765e053acd07baa055c96b2065c7fab91f911b3c076dfea71006666f5b0/ruff-0.8.6-py3-none-win_arm64.whl", hash = "sha256:7d7fc2377a04b6e04ffe588caad613d0c460eb2ecba4c0ccbbfe2bc973cbc162", size = 9149556 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request includes significant updates to the CI workflow, Kubernetes integration, and testing infrastructure. The most important changes involve renaming and restructuring CI jobs, adding support for multiple Kubernetes versions, and refactoring the cluster management code.

### CI Workflow Updates:
* Renamed the `test` job to `test-python` and added new jobs `test-k8s` and `test-provider` to support testing with different Kubernetes versions and providers. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL13-R13) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR53-R123)
* Removed the condition to upload coverage to Codecov only for specific Python versions.

### Kubernetes Integration:
* Updated the `README.md` to include installation instructions for specific Kubernetes versions.
* Added new dependencies for specific Kubernetes versions in `pyproject.toml`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R21) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R32-R35) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L109-R119)

### Cluster Management Refactor:
* Introduced new classes `K3DCluster` and `KindCluster` to manage Kubernetes clusters in `cloudcoil/_testing/clusters.py`.
* Refactored the `test_cluster` fixture in `cloudcoil/_testing/plugin.py` to use the new cluster management classes.

### Testing Enhancements:
* Modified the end-to-end tests in `tests/test_e2e.py` to dynamically determine the Kubernetes version and provider. [[1]](diffhunk://#diff-ed3b8af48cd21dc1ac735b839d89b172a6f45569c324af70a2bdb4f60e5fbcddR3-R20) [[2]](diffhunk://#diff-ed3b8af48cd21dc1ac735b839d89b172a6f45569c324af70a2bdb4f60e5fbcddL48-R40)

### Minor Fixes:
* Fixed a potential `None` type error in the `__len__` method of the `resource_list` class in `cloudcoil/resources.py`.