### PR TITLE
Remove deperecated substitutions class

### DIFF
--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -3,7 +3,13 @@ from pathlib import Path
 
 import pytest
 
-from cloudcoil.codegen.generator import ModelConfig, Substitution, generate, process_definitions
+from cloudcoil.codegen.generator import (
+    ModelConfig,
+    Substitution,
+    Transformation,
+    generate,
+    process_definitions,
+)
 
 K8S_OPENAPI_URL = str(Path(__file__).parent / "data" / "k8s-swagger.json")
 
@@ -33,18 +39,14 @@ def model_config(tmp_path):
     return ModelConfig(
         namespace="test.k8s",
         input_=K8S_OPENAPI_URL,
-        substitutions=[
-            Substitution(
-                from_=r"^io\.k8s\.apimachinery\..*\.(.+)",
-                to=r"apimachinery.\g<1>",
+        transformations=[
+            Transformation(
+                match_=r"^io\.k8s\.apimachinery\..*\.(.+)",
+                replace=r"apimachinery.\g<1>",
                 namespace="cloudcoil",
             ),
-            Substitution(
-                from_=r"^io\.k8s\.apiextensions-apiserver\.pkg\.apis\.apiextensions\.(.+)$",
-                to=r"apiextensions.\g<1>",
-            ),
-            Substitution(from_=r"^io\.k8s\.api\.(.+)$", to=r"\g<1>"),
-            Substitution(from_=r"^io\.k8s\.kube-aggregator\.pkg\.apis\.(.+)$", to=r"\g<1>"),
+            Transformation(match_=r"^io\.k8s\.api\.(core|apps.*)$", replace=r"\g<1>"),
+            Transformation(match_=r"^,*$", exclude=True),
         ],
     )
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1,11 +1,9 @@
-import re
 from pathlib import Path
 
 import pytest
 
 from cloudcoil.codegen.generator import (
     ModelConfig,
-    Substitution,
     Transformation,
     generate,
     process_definitions,
@@ -51,18 +49,12 @@ def model_config(tmp_path):
     )
 
 
-def test_substitution():
-    subs = Substitution(from_="io.k8s.api.(.+)", to="k8s.\\1")
-    assert isinstance(subs.from_, re.Pattern)
-    assert subs.to == "k8s.\\1"
-
-
 def test_model_config_validation():
     config = ModelConfig(
         namespace="test",
         input_="test.json",
-        substitutions=[
-            Substitution(from_="test", to="replaced"),
+        transformations=[
+            Transformation(match_="test", replace="replaced"),
         ],
     )
     assert config.namespace == "test"
@@ -202,14 +194,6 @@ def test_generate_without_init_files(tmp_path):
 
 
 def test_model_config_validation_errors():
-    with pytest.raises(ValueError, match="Only transformations can be used"):
-        ModelConfig(
-            namespace="test",
-            input_="test.json",
-            substitutions=[Substitution(from_="test", to="replaced")],
-            transformations=[{"match": "test", "replace": "other"}],
-        )
-
     with pytest.raises(ValueError, match="replace is required"):
         ModelConfig(
             namespace="test",


### PR DESCRIPTION
This pull request includes significant changes to the `cloudcoil/codegen/generator.py` file, primarily focusing on removing the `Substitution` class and updating the `ModelConfig` class to use the `Transformation` class instead. Additionally, corresponding tests in `tests/test_codegen.py` have been updated to reflect these changes.

Key changes include:

### Removal of `Substitution` class:
* The `Substitution` class has been removed from `cloudcoil/codegen/generator.py`.

### Updates to `ModelConfig` class:
* The `substitutions` attribute has been removed from the `ModelConfig` class, and the `transformations` attribute is now used exclusively.
* The `_add_namespace` method in the `ModelConfig` class has been simplified to remove logic related to `substitutions`.

### Test updates:
* Import statements in `tests/test_codegen.py` have been updated to remove `Substitution` and include `Transformation`.
* Test cases have been updated to use `Transformation` instead of `Substitution`. This includes changes to the `model_config` fixture and the `test_model_config_validation` test. [[1]](diffhunk://#diff-1582e084856121640b055f625172ffcfef41bb645dc43ba7abf8b9eb161e47e1L36-R57) [[2]](diffhunk://#diff-1582e084856121640b055f625172ffcfef41bb645dc43ba7abf8b9eb161e47e1L203-L210)