### PR TITLE
Add support for waiting for resources

### DIFF
--- a/cloudcoil/_context.py
+++ b/cloudcoil/_context.py
@@ -5,6 +5,7 @@ if TYPE_CHECKING:
     from cloudcoil.client._config import Config
 
 _configs = ContextVar("_configs", default=None)
+_default_config = None
 
 
 class _Context:
@@ -17,12 +18,16 @@ class _Context:
         if self.configs:
             self.configs.pop()
 
+    def set_default(self, config: "Config") -> None:
+        global _default_config
+        _default_config = config
+
     @property
     def active_config(self) -> "Config":
         if not self.configs:
             from cloudcoil.client._config import Config
 
-            config = Config()
+            config = _default_config or Config()
             self.configs = [config]
         return self.configs[-1]
 

--- a/cloudcoil/client/_config.py
+++ b/cloudcoil/client/_config.py
@@ -343,6 +343,9 @@ class Config:
             client=self.async_client,
         )
 
+    def set_default(self) -> None:
+        context.set_default(self)
+
     def initialize(self):
         if not self._rest_mapping:
             self._create_rest_mapper()

--- a/cloudcoil/errors.py
+++ b/cloudcoil/errors.py
@@ -8,3 +8,11 @@ class ResourceNotFound(APIError):
 
 class ResourceAlreadyExists(APIError):
     pass
+
+
+class WatchError(APIError):
+    pass
+
+
+class WaitTimeout(APIError):
+    pass


### PR DESCRIPTION
This pull request introduces several significant changes to the `cloudcoil` project, focusing on adding wait functionality for Kubernetes resources, enhancing the context management, and updating the API client and resources. The most important changes include adding synchronous and asynchronous `wait_for` methods, introducing new error classes, and updating the `README.md` to include examples of the new wait functionality.

### Enhancements to Kubernetes resource management:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R139-R158): Added examples demonstrating how to wait for a Kubernetes resource to reach a desired state using the new `wait_for` methods.

### Context management improvements:

* [`cloudcoil/_context.py`](diffhunk://#diff-ad2653b1893716834d3b31fa3e036b68cd951757894f03246d10d929d8b362a3R8): Introduced a `set_default` method to set a default configuration and updated the `active_config` property to use this default configuration if no other configurations are available. [[1]](diffhunk://#diff-ad2653b1893716834d3b31fa3e036b68cd951757894f03246d10d929d8b362a3R8) [[2]](diffhunk://#diff-ad2653b1893716834d3b31fa3e036b68cd951757894f03246d10d929d8b362a3R21-R30)

### API client updates:

* [`cloudcoil/client/_api_client.py`](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066R5-R32): Added synchronous and asynchronous `wait_for` methods to the API client, allowing users to wait for specific conditions on resources. Updated the `watch` method to use a new `WatchEvent` type. [[1]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066R5-R32) [[2]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066L90-R99) [[3]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066L272-R281) [[4]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066L287-R296) [[5]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066R339-R395) [[6]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066L504-R570) [[7]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066R612-R636)

### Error handling enhancements:

* [`cloudcoil/errors.py`](diffhunk://#diff-049066d5b3b5b4333642e307217978faea6171375a27d2fb9bdcd7ccc865fe26R11-R18): Added new error classes `WatchError` and `WaitTimeout` to handle errors related to watching and waiting for resources.

### Resource class updates:

* [`cloudcoil/resources.py`](diffhunk://#diff-28ee8ca35baf82b268e2abca5cb5c69432a1076316b6c0ddc82fe141d817ec40R12): Added `wait_for` and `async_wait_for` methods to the `Resource` class, allowing users to wait for specific conditions on resources. Introduced new types `WatchEvent` and `WaitPredicate`. [[1]](diffhunk://#diff-28ee8ca35baf82b268e2abca5cb5c69432a1076316b6c0ddc82fe141d817ec40R12) [[2]](diffhunk://#diff-28ee8ca35baf82b268e2abca5cb5c69432a1076316b6c0ddc82fe141d817ec40R36-R37) [[3]](diffhunk://#diff-28ee8ca35baf82b268e2abca5cb5c69432a1076316b6c0ddc82fe141d817ec40R108-R113) [[4]](diffhunk://#diff-28ee8ca35baf82b268e2abca5cb5c69432a1076316b6c0ddc82fe141d817ec40L311-R320) [[5]](diffhunk://#diff-28ee8ca35baf82b268e2abca5cb5c69432a1076316b6c0ddc82fe141d817ec40L329-R338) [[6]](diffhunk://#diff-28ee8ca35baf82b268e2abca5cb5c69432a1076316b6c0ddc82fe141d817ec40R348-R411)

These changes collectively improve the usability and functionality of the `cloudcoil` project, enabling more robust and flexible interactions with Kubernetes resources.