### PR TITLE
Add support for openapi v3 and CRDs

### DIFF
--- a/cloudcoil/_pydantic.py
+++ b/cloudcoil/_pydantic.py
@@ -1,7 +1,1 @@
-import pydantic
-
-
-class BaseModel(pydantic.BaseModel):
-    model_config = pydantic.ConfigDict(
-        populate_by_name=True,
-    )
+from .pydantic import BaseModel as BaseModel

--- a/cloudcoil/apimachinery.py
+++ b/cloudcoil/apimachinery.py
@@ -8,7 +8,7 @@ from typing import Annotated, Dict, List, Literal, Optional, Union
 
 from pydantic import Field, RootModel
 
-from cloudcoil._pydantic import BaseModel
+from cloudcoil.pydantic import BaseModel
 
 
 class Quantity(RootModel[str]):

--- a/cloudcoil/pydantic.py
+++ b/cloudcoil/pydantic.py
@@ -1,0 +1,7 @@
+import pydantic
+
+
+class BaseModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(
+        populate_by_name=True,
+    )

--- a/cloudcoil/resources.py
+++ b/cloudcoil/resources.py
@@ -22,9 +22,9 @@ import yaml
 from pydantic import ConfigDict, Field, create_model, model_validator
 
 from cloudcoil._context import context
-from cloudcoil._pydantic import BaseModel
 from cloudcoil.apimachinery import ListMeta, ObjectMeta, Status
 from cloudcoil.errors import ResourceNotFound
+from cloudcoil.pydantic import BaseModel
 
 if sys.version_info >= (3, 11):
     from typing import Self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ omit = [
     "cloudcoil/_testing/**",
     "cloudcoil/codegen/_tomllib/**",
     "cloudcoil/apimachinery.py",
+    "cloudcoil/pydantic.py",
     "cloudcoil/_pydantic.py",
 ]
 


### PR DESCRIPTION
This pull request includes significant updates to the `cloudcoil/codegen/generator.py` file to enhance schema processing and support additional command-line arguments. The changes include improvements to schema detection, transformation processing, and handling of both JSON and YAML inputs.

Schema processing improvements:

* Added functions to detect schema type (`detect_schema_type`), get and set schema definitions (`get_schema_definitions`, `set_schema_definitions`), and process definitions for both JSONSchema and OpenAPI formats (`process_definitions`). [[1]](diffhunk://#diff-e20a70c20872264a870680b7b56b68e61f1bb2e5317c1275afc3a94739cbb218L66-R126) [[2]](diffhunk://#diff-e20a70c20872264a870680b7b56b68e61f1bb2e5317c1275afc3a94739cbb218L95-R160)
* Introduced functions to convert CustomResourceDefinitions (CRDs) to OpenAPI schemas (`convert_crd_to_schema`) and merge multiple schemas (`merge_schemas`).

Transformation processing enhancements:

* Modified the `_add_namespace` method in `ModelConfig` to handle CRD namespaces and resource mode transformations.
* Updated `process_transformations` to rename definitions and fix references based on schema type.

Handling of JSON and YAML inputs:

* Added functions to load YAML documents from files and strings (`load_yaml_documents`, `load_yaml_content`) and fetch remote content (`fetch_remote_content`).
* Enhanced `process_input` to support both local and remote YAML and JSON inputs, including CRD conversion and schema merging.

Additional command-line arguments:

* Added new arguments `--crd-namespace` and `--additional-codegen-arg` to the argument parser to support CRD namespaces and additional code generation arguments. [[1]](diffhunk://#diff-e20a70c20872264a870680b7b56b68e61f1bb2e5317c1275afc3a94739cbb218R642-R653) [[2]](diffhunk://#diff-e20a70c20872264a870680b7b56b68e61f1bb2e5317c1275afc3a94739cbb218R701-R702)

File updates:

* Renamed `cloudcoil/_pydantic.py` to `cloudcoil/pydantic.py` and updated references accordingly. [[1]](diffhunk://#diff-e20a70c20872264a870680b7b56b68e61f1bb2e5317c1275afc3a94739cbb218L11-R15) [[2]](diffhunk://#diff-e20a70c20872264a870680b7b56b68e61f1bb2e5317c1275afc3a94739cbb218L299-R523) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L109-R109)