### PR TITLE
Move to a builder based fluent API

### DIFF
--- a/cloudcoil/apimachinery.py
+++ b/cloudcoil/apimachinery.py
@@ -4,14 +4,33 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Annotated, Callable, Dict, List, Literal, Optional, Type, Union
+from typing import Annotated, Callable, Dict, List, Literal, Optional, Type, Union, cast
 
 from pydantic import Field, RootModel
 
-from cloudcoil.pydantic import BaseBuilder, BaseModel, ListBuilder, Self
+from cloudcoil.pydantic import BaseBuilder, BaseModel, GenericListBuilder, Self
 
 
 class Quantity(RootModel[str]):
+    class Builder(BaseModel):
+        _value: str | None = None
+
+        @property
+        def base_class(self) -> Type["Quantity"]:
+            return Quantity
+
+        def root(self, value: str) -> Self:
+            self._value = value
+            return self
+
+        def __call__(self, value: str) -> Self:
+            self._value = value
+            return self
+
+        def build(self) -> "Quantity":
+            value = cast(str, self._value)
+            return Quantity(value)
+
     root: Annotated[
         str,
         Field(
@@ -19,9 +38,27 @@ class Quantity(RootModel[str]):
         ),
     ]
 
+    @classmethod
+    def builder(cls) -> Builder:
+        return cls.Builder()
+
+    class ListBuilder(GenericListBuilder["Quantity", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use Quantity.list_builder() instead."
+            )
+
+    @classmethod
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
+
 
 class APIResource(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["APIResource"]:
+            return APIResource
+
         def build(self) -> "APIResource":
             return APIResource(**self._attrs)
 
@@ -59,9 +96,15 @@ class APIResource(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["APIResource", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use APIResource.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     categories: Annotated[
         Optional[List[str]],
@@ -123,6 +166,10 @@ class APIResource(BaseModel):
 
 class APIResourceList(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["APIResourceList"]:
+            return APIResourceList
+
         def build(self) -> "APIResourceList":
             return APIResourceList(**self._attrs)
 
@@ -135,24 +182,36 @@ class APIResourceList(BaseModel):
         def kind(self, value: Optional[Literal["APIResourceList"]]) -> Self:
             return self._set("kind", value)
 
+        """  """
+
         def resources(
             self,
             value_or_callback: Union[
-                List[APIResource], Callable[[Type[APIResource]], List[APIResource]]
+                List[APIResource],
+                Callable[
+                    [GenericListBuilder[APIResource, APIResource.Builder]],
+                    GenericListBuilder[APIResource, APIResource.Builder],
+                ],
             ],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(APIResource)
+                value = value_or_callback(APIResource.list_builder()).build()
             return self._set("resources", value)
 
     @classmethod
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["APIResourceList", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use APIResourceList.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     api_version: Annotated[
         Optional[Literal["v1"]],
@@ -184,6 +243,10 @@ class APIResourceList(BaseModel):
 
 class FieldSelectorRequirement(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["FieldSelectorRequirement"]:
+            return FieldSelectorRequirement
+
         def build(self) -> "FieldSelectorRequirement":
             return FieldSelectorRequirement(**self._attrs)
 
@@ -200,9 +263,15 @@ class FieldSelectorRequirement(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["FieldSelectorRequirement", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use FieldSelectorRequirement.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     key: Annotated[
         str,
@@ -224,6 +293,10 @@ class FieldSelectorRequirement(BaseModel):
 
 class FieldsV1(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["FieldsV1"]:
+            return FieldsV1
+
         def build(self) -> "FieldsV1":
             return FieldsV1(**self._attrs)
 
@@ -231,15 +304,25 @@ class FieldsV1(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["FieldsV1", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use FieldsV1.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     pass
 
 
 class GroupVersionForDiscovery(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["GroupVersionForDiscovery"]:
+            return GroupVersionForDiscovery
+
         def build(self) -> "GroupVersionForDiscovery":
             return GroupVersionForDiscovery(**self._attrs)
 
@@ -253,9 +336,15 @@ class GroupVersionForDiscovery(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["GroupVersionForDiscovery", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use GroupVersionForDiscovery.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     group_version: Annotated[
         str,
@@ -274,6 +363,10 @@ class GroupVersionForDiscovery(BaseModel):
 
 class LabelSelectorRequirement(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["LabelSelectorRequirement"]:
+            return LabelSelectorRequirement
+
         def build(self) -> "LabelSelectorRequirement":
             return LabelSelectorRequirement(**self._attrs)
 
@@ -290,9 +383,15 @@ class LabelSelectorRequirement(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["LabelSelectorRequirement", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use LabelSelectorRequirement.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     key: Annotated[str, Field(description="key is the label key that the selector applies to.")]
     operator: Annotated[
@@ -311,6 +410,10 @@ class LabelSelectorRequirement(BaseModel):
 
 class ListMeta(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["ListMeta"]:
+            return ListMeta
+
         def build(self) -> "ListMeta":
             return ListMeta(**self._attrs)
 
@@ -330,9 +433,15 @@ class ListMeta(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["ListMeta", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use ListMeta.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     continue_: Annotated[
         Optional[str],
@@ -365,14 +474,51 @@ class ListMeta(BaseModel):
 
 
 class MicroTime(RootModel[datetime]):
+    class Builder(BaseModel):
+        _value: datetime | None = None
+
+        @property
+        def base_class(self) -> Type["MicroTime"]:
+            return MicroTime
+
+        def root(self, value: datetime) -> Self:
+            self._value = value
+            return self
+
+        def __call__(self, value: datetime) -> Self:
+            self._value = value
+            return self
+
+        def build(self) -> "MicroTime":
+            value = cast(datetime, self._value)
+            return MicroTime(value)
+
     root: Annotated[
         datetime,
         Field(description="MicroTime is version of Time with microsecond level precision."),
     ]
 
+    @classmethod
+    def builder(cls) -> Builder:
+        return cls.Builder()
+
+    class ListBuilder(GenericListBuilder["MicroTime", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use MicroTime.list_builder() instead."
+            )
+
+    @classmethod
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
+
 
 class OwnerReference(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["OwnerReference"]:
+            return OwnerReference
+
         def build(self) -> "OwnerReference":
             return OwnerReference(**self._attrs)
 
@@ -398,9 +544,15 @@ class OwnerReference(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["OwnerReference", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use OwnerReference.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     api_version: Annotated[
         str, Field(alias="apiVersion", description="API version of the referent.")
@@ -438,6 +590,10 @@ class OwnerReference(BaseModel):
 
 class Patch(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["Patch"]:
+            return Patch
+
         def build(self) -> "Patch":
             return Patch(**self._attrs)
 
@@ -445,15 +601,25 @@ class Patch(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["Patch", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use Patch.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     pass
 
 
 class Preconditions(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["Preconditions"]:
+            return Preconditions
+
         def build(self) -> "Preconditions":
             return Preconditions(**self._attrs)
 
@@ -467,9 +633,15 @@ class Preconditions(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["Preconditions", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use Preconditions.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     resource_version: Annotated[
         Optional[str],
@@ -480,6 +652,10 @@ class Preconditions(BaseModel):
 
 class ServerAddressByClientCIDR(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["ServerAddressByClientCIDR"]:
+            return ServerAddressByClientCIDR
+
         def build(self) -> "ServerAddressByClientCIDR":
             return ServerAddressByClientCIDR(**self._attrs)
 
@@ -493,9 +669,15 @@ class ServerAddressByClientCIDR(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["ServerAddressByClientCIDR", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use ServerAddressByClientCIDR.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     client_cidr: Annotated[
         str,
@@ -515,6 +697,10 @@ class ServerAddressByClientCIDR(BaseModel):
 
 class StatusCause(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["StatusCause"]:
+            return StatusCause
+
         def build(self) -> "StatusCause":
             return StatusCause(**self._attrs)
 
@@ -531,9 +717,15 @@ class StatusCause(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["StatusCause", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use StatusCause.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     field: Annotated[
         Optional[str],
@@ -557,19 +749,28 @@ class StatusCause(BaseModel):
 
 class StatusDetails(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["StatusDetails"]:
+            return StatusDetails
+
         def build(self) -> "StatusDetails":
             return StatusDetails(**self._attrs)
+
+        """  """
 
         def causes(
             self,
             value_or_callback: Union[
                 Optional[List[StatusCause]],
-                Callable[[Type[StatusCause]], List[StatusCause]],
+                Callable[
+                    [GenericListBuilder[StatusCause, StatusCause.Builder]],
+                    GenericListBuilder[StatusCause, StatusCause.Builder],
+                ],
             ],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(StatusCause)
+                value = value_or_callback(StatusCause.list_builder()).build()
             return self._set("causes", value)
 
         def group(self, value: Optional[str]) -> Self:
@@ -591,9 +792,15 @@ class StatusDetails(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["StatusDetails", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use StatusDetails.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     causes: Annotated[
         Optional[List[StatusCause]],
@@ -635,6 +842,25 @@ class StatusDetails(BaseModel):
 
 
 class Time(RootModel[datetime]):
+    class Builder(BaseModel):
+        _value: datetime | None = None
+
+        @property
+        def base_class(self) -> Type["Time"]:
+            return Time
+
+        def root(self, value: datetime) -> Self:
+            self._value = value
+            return self
+
+        def __call__(self, value: datetime) -> Self:
+            self._value = value
+            return self
+
+        def build(self) -> "Time":
+            value = cast(datetime, self._value)
+            return Time(value)
+
     root: Annotated[
         datetime,
         Field(
@@ -642,9 +868,27 @@ class Time(RootModel[datetime]):
         ),
     ]
 
+    @classmethod
+    def builder(cls) -> Builder:
+        return cls.Builder()
+
+    class ListBuilder(GenericListBuilder["Time", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use Time.list_builder() instead."
+            )
+
+    @classmethod
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
+
 
 class RawExtension(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["RawExtension"]:
+            return RawExtension
+
         def build(self) -> "RawExtension":
             return RawExtension(**self._attrs)
 
@@ -652,14 +896,39 @@ class RawExtension(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["RawExtension", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use RawExtension.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     pass
 
 
 class IntOrString(RootModel[Union[int, str]]):
+    class Builder(BaseModel):
+        _value: Union[int, str] | None = None
+
+        @property
+        def base_class(self) -> Type["IntOrString"]:
+            return IntOrString
+
+        def root(self, value: Union[int, str]) -> Self:
+            self._value = value
+            return self
+
+        def __call__(self, value: Union[int, str]) -> Self:
+            self._value = value
+            return self
+
+        def build(self) -> "IntOrString":
+            value = cast(Union[int, str], self._value)
+            return IntOrString(value)
+
     root: Annotated[
         Union[int, str],
         Field(
@@ -667,9 +936,27 @@ class IntOrString(RootModel[Union[int, str]]):
         ),
     ]
 
+    @classmethod
+    def builder(cls) -> Builder:
+        return cls.Builder()
+
+    class ListBuilder(GenericListBuilder["IntOrString", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use IntOrString.list_builder() instead."
+            )
+
+    @classmethod
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
+
 
 class Info(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["Info"]:
+            return Info
+
         def build(self) -> "Info":
             return Info(**self._attrs)
 
@@ -704,9 +991,15 @@ class Info(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["Info", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use Info.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     build_date: Annotated[str, Field(alias="buildDate")]
     compiler: str
@@ -721,6 +1014,10 @@ class Info(BaseModel):
 
 class APIGroup(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["APIGroup"]:
+            return APIGroup
+
         def build(self) -> "APIGroup":
             return APIGroup(**self._attrs)
 
@@ -733,49 +1030,77 @@ class APIGroup(BaseModel):
         def name(self, value: str) -> Self:
             return self._set("name", value)
 
+        """  """
+
         def preferred_version(
             self,
             value_or_callback: Union[
                 Optional[GroupVersionForDiscovery],
-                Callable[[Type[GroupVersionForDiscovery]], GroupVersionForDiscovery],
+                Callable[[GroupVersionForDiscovery.Builder], GroupVersionForDiscovery.Builder],
             ],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(GroupVersionForDiscovery)
+                value = value_or_callback(GroupVersionForDiscovery.builder()).build()
             return self._set("preferred_version", value)
+
+        """  """
 
         def server_address_by_client_cid_rs(
             self,
             value_or_callback: Union[
                 Optional[List[ServerAddressByClientCIDR]],
-                Callable[[Type[ServerAddressByClientCIDR]], List[ServerAddressByClientCIDR]],
+                Callable[
+                    [
+                        GenericListBuilder[
+                            ServerAddressByClientCIDR, ServerAddressByClientCIDR.Builder
+                        ]
+                    ],
+                    GenericListBuilder[
+                        ServerAddressByClientCIDR, ServerAddressByClientCIDR.Builder
+                    ],
+                ],
             ],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(ServerAddressByClientCIDR)
+                value = value_or_callback(ServerAddressByClientCIDR.list_builder()).build()
             return self._set("server_address_by_client_cid_rs", value)
+
+        """  """
 
         def versions(
             self,
             value_or_callback: Union[
                 List[GroupVersionForDiscovery],
-                Callable[[Type[GroupVersionForDiscovery]], List[GroupVersionForDiscovery]],
+                Callable[
+                    [
+                        GenericListBuilder[
+                            GroupVersionForDiscovery, GroupVersionForDiscovery.Builder
+                        ]
+                    ],
+                    GenericListBuilder[GroupVersionForDiscovery, GroupVersionForDiscovery.Builder],
+                ],
             ],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(GroupVersionForDiscovery)
+                value = value_or_callback(GroupVersionForDiscovery.list_builder()).build()
             return self._set("versions", value)
 
     @classmethod
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["APIGroup", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use APIGroup.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     api_version: Annotated[
         Optional[Literal["v1"]],
@@ -813,19 +1138,31 @@ class APIGroup(BaseModel):
 
 class APIGroupList(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["APIGroupList"]:
+            return APIGroupList
+
         def build(self) -> "APIGroupList":
             return APIGroupList(**self._attrs)
 
         def api_version(self, value: Optional[Literal["v1"]]) -> Self:
             return self._set("api_version", value)
 
+        """  """
+
         def groups(
             self,
-            value_or_callback: Union[List[APIGroup], Callable[[Type[APIGroup]], List[APIGroup]]],
+            value_or_callback: Union[
+                List[APIGroup],
+                Callable[
+                    [GenericListBuilder[APIGroup, APIGroup.Builder]],
+                    GenericListBuilder[APIGroup, APIGroup.Builder],
+                ],
+            ],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(APIGroup)
+                value = value_or_callback(APIGroup.list_builder()).build()
             return self._set("groups", value)
 
         def kind(self, value: Optional[Literal["APIGroupList"]]) -> Self:
@@ -835,9 +1172,15 @@ class APIGroupList(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["APIGroupList", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use APIGroupList.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     api_version: Annotated[
         Optional[Literal["v1"]],
@@ -857,6 +1200,10 @@ class APIGroupList(BaseModel):
 
 class APIVersions(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["APIVersions"]:
+            return APIVersions
+
         def build(self) -> "APIVersions":
             return APIVersions(**self._attrs)
 
@@ -866,16 +1213,27 @@ class APIVersions(BaseModel):
         def kind(self, value: Optional[Literal["APIVersions"]]) -> Self:
             return self._set("kind", value)
 
+        """  """
+
         def server_address_by_client_cid_rs(
             self,
             value_or_callback: Union[
                 List[ServerAddressByClientCIDR],
-                Callable[[Type[ServerAddressByClientCIDR]], List[ServerAddressByClientCIDR]],
+                Callable[
+                    [
+                        GenericListBuilder[
+                            ServerAddressByClientCIDR, ServerAddressByClientCIDR.Builder
+                        ]
+                    ],
+                    GenericListBuilder[
+                        ServerAddressByClientCIDR, ServerAddressByClientCIDR.Builder
+                    ],
+                ],
             ],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(ServerAddressByClientCIDR)
+                value = value_or_callback(ServerAddressByClientCIDR.list_builder()).build()
             return self._set("server_address_by_client_cid_rs", value)
 
         def versions(self, value: List[str]) -> Self:
@@ -885,9 +1243,15 @@ class APIVersions(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["APIVersions", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use APIVersions.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     api_version: Annotated[
         Optional[Literal["v1"]],
@@ -917,15 +1281,21 @@ class APIVersions(BaseModel):
 
 class Condition(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["Condition"]:
+            return Condition
+
         def build(self) -> "Condition":
             return Condition(**self._attrs)
 
+        """  """
+
         def last_transition_time(
-            self, value_or_callback: Union[Time, Callable[[Type[Time]], Time]]
+            self, value_or_callback: Union[Time, Callable[[Time.Builder], Time.Builder]]
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(Time)
+                value = value_or_callback(Time.builder()).build()
             return self._set("last_transition_time", value)
 
         def message(self, value: str) -> Self:
@@ -947,9 +1317,15 @@ class Condition(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["Condition", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use Condition.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     last_transition_time: Annotated[
         Time,
@@ -988,6 +1364,10 @@ class Condition(BaseModel):
 
 class DeleteOptions(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["DeleteOptions"]:
+            return DeleteOptions
+
         def build(self) -> "DeleteOptions":
             return DeleteOptions(**self._attrs)
 
@@ -1006,15 +1386,18 @@ class DeleteOptions(BaseModel):
         def orphan_dependents(self, value: Optional[bool]) -> Self:
             return self._set("orphan_dependents", value)
 
+        """  """
+
         def preconditions(
             self,
             value_or_callback: Union[
-                Optional[Preconditions], Callable[[Type[Preconditions]], Preconditions]
+                Optional[Preconditions],
+                Callable[[Preconditions.Builder], Preconditions.Builder],
             ],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(Preconditions)
+                value = value_or_callback(Preconditions.builder()).build()
             return self._set("preconditions", value)
 
         def propagation_policy(self, value: Optional[str]) -> Self:
@@ -1024,9 +1407,15 @@ class DeleteOptions(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["DeleteOptions", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use DeleteOptions.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     api_version: Annotated[
         Optional[Literal["v1"]],
@@ -1079,19 +1468,32 @@ class DeleteOptions(BaseModel):
 
 class LabelSelector(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["LabelSelector"]:
+            return LabelSelector
+
         def build(self) -> "LabelSelector":
             return LabelSelector(**self._attrs)
+
+        """  """
 
         def match_expressions(
             self,
             value_or_callback: Union[
                 Optional[List[LabelSelectorRequirement]],
-                Callable[[Type[LabelSelectorRequirement]], List[LabelSelectorRequirement]],
+                Callable[
+                    [
+                        GenericListBuilder[
+                            LabelSelectorRequirement, LabelSelectorRequirement.Builder
+                        ]
+                    ],
+                    GenericListBuilder[LabelSelectorRequirement, LabelSelectorRequirement.Builder],
+                ],
             ],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(LabelSelectorRequirement)
+                value = value_or_callback(LabelSelectorRequirement.list_builder()).build()
             return self._set("match_expressions", value)
 
         def match_labels(self, value: Optional[Dict[str, str]]) -> Self:
@@ -1101,9 +1503,15 @@ class LabelSelector(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["LabelSelector", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use LabelSelector.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     match_expressions: Annotated[
         Optional[List[LabelSelectorRequirement]],
@@ -1123,6 +1531,10 @@ class LabelSelector(BaseModel):
 
 class ManagedFieldsEntry(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["ManagedFieldsEntry"]:
+            return ManagedFieldsEntry
+
         def build(self) -> "ManagedFieldsEntry":
             return ManagedFieldsEntry(**self._attrs)
 
@@ -1132,13 +1544,17 @@ class ManagedFieldsEntry(BaseModel):
         def fields_type(self, value: Optional[str]) -> Self:
             return self._set("fields_type", value)
 
+        """  """
+
         def fields_v1(
             self,
-            value_or_callback: Union[Optional[FieldsV1], Callable[[Type[FieldsV1]], FieldsV1]],
+            value_or_callback: Union[
+                Optional[FieldsV1], Callable[[FieldsV1.Builder], FieldsV1.Builder]
+            ],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(FieldsV1)
+                value = value_or_callback(FieldsV1.builder()).build()
             return self._set("fields_v1", value)
 
         def manager(self, value: Optional[str]) -> Self:
@@ -1150,21 +1566,30 @@ class ManagedFieldsEntry(BaseModel):
         def subresource(self, value: Optional[str]) -> Self:
             return self._set("subresource", value)
 
+        """  """
+
         def time(
-            self, value_or_callback: Union[Optional[Time], Callable[[Type[Time]], Time]]
+            self,
+            value_or_callback: Union[Optional[Time], Callable[[Time.Builder], Time.Builder]],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(Time)
+                value = value_or_callback(Time.builder()).build()
             return self._set("time", value)
 
     @classmethod
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["ManagedFieldsEntry", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use ManagedFieldsEntry.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     api_version: Annotated[
         Optional[str],
@@ -1213,29 +1638,39 @@ class ManagedFieldsEntry(BaseModel):
 
 class ObjectMeta(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["ObjectMeta"]:
+            return ObjectMeta
+
         def build(self) -> "ObjectMeta":
             return ObjectMeta(**self._attrs)
 
         def annotations(self, value: Optional[Dict[str, str]]) -> Self:
             return self._set("annotations", value)
 
+        """  """
+
         def creation_timestamp(
-            self, value_or_callback: Union[Optional[Time], Callable[[Type[Time]], Time]]
+            self,
+            value_or_callback: Union[Optional[Time], Callable[[Time.Builder], Time.Builder]],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(Time)
+                value = value_or_callback(Time.builder()).build()
             return self._set("creation_timestamp", value)
 
         def deletion_grace_period_seconds(self, value: Optional[int]) -> Self:
             return self._set("deletion_grace_period_seconds", value)
 
+        """  """
+
         def deletion_timestamp(
-            self, value_or_callback: Union[Optional[Time], Callable[[Type[Time]], Time]]
+            self,
+            value_or_callback: Union[Optional[Time], Callable[[Time.Builder], Time.Builder]],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(Time)
+                value = value_or_callback(Time.builder()).build()
             return self._set("deletion_timestamp", value)
 
         def finalizers(self, value: Optional[List[str]]) -> Self:
@@ -1250,16 +1685,21 @@ class ObjectMeta(BaseModel):
         def labels(self, value: Optional[Dict[str, str]]) -> Self:
             return self._set("labels", value)
 
+        """  """
+
         def managed_fields(
             self,
             value_or_callback: Union[
                 Optional[List[ManagedFieldsEntry]],
-                Callable[[Type[ManagedFieldsEntry]], List[ManagedFieldsEntry]],
+                Callable[
+                    [GenericListBuilder[ManagedFieldsEntry, ManagedFieldsEntry.Builder]],
+                    GenericListBuilder[ManagedFieldsEntry, ManagedFieldsEntry.Builder],
+                ],
             ],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(ManagedFieldsEntry)
+                value = value_or_callback(ManagedFieldsEntry.list_builder()).build()
             return self._set("managed_fields", value)
 
         def name(self, value: Optional[str]) -> Self:
@@ -1268,16 +1708,21 @@ class ObjectMeta(BaseModel):
         def namespace(self, value: Optional[str]) -> Self:
             return self._set("namespace", value)
 
+        """  """
+
         def owner_references(
             self,
             value_or_callback: Union[
                 Optional[List[OwnerReference]],
-                Callable[[Type[OwnerReference]], List[OwnerReference]],
+                Callable[
+                    [GenericListBuilder[OwnerReference, OwnerReference.Builder]],
+                    GenericListBuilder[OwnerReference, OwnerReference.Builder],
+                ],
             ],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(OwnerReference)
+                value = value_or_callback(OwnerReference.list_builder()).build()
             return self._set("owner_references", value)
 
         def resource_version(self, value: Optional[str]) -> Self:
@@ -1293,9 +1738,15 @@ class ObjectMeta(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["ObjectMeta", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use ObjectMeta.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     annotations: Annotated[
         Optional[Dict[str, str]],
@@ -1399,6 +1850,10 @@ class ObjectMeta(BaseModel):
 
 class Status(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["Status"]:
+            return Status
+
         def build(self) -> "Status":
             return Status(**self._attrs)
 
@@ -1408,15 +1863,18 @@ class Status(BaseModel):
         def code(self, value: Optional[int]) -> Self:
             return self._set("code", value)
 
+        """  """
+
         def details(
             self,
             value_or_callback: Union[
-                Optional[StatusDetails], Callable[[Type[StatusDetails]], StatusDetails]
+                Optional[StatusDetails],
+                Callable[[StatusDetails.Builder], StatusDetails.Builder],
             ],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(StatusDetails)
+                value = value_or_callback(StatusDetails.builder()).build()
             return self._set("details", value)
 
         def kind(self, value: Optional[Literal["Status"]]) -> Self:
@@ -1425,13 +1883,17 @@ class Status(BaseModel):
         def message(self, value: Optional[str]) -> Self:
             return self._set("message", value)
 
+        """  """
+
         def metadata(
             self,
-            value_or_callback: Union[Optional[ListMeta], Callable[[Type[ListMeta]], ListMeta]],
+            value_or_callback: Union[
+                Optional[ListMeta], Callable[[ListMeta.Builder], ListMeta.Builder]
+            ],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(ListMeta)
+                value = value_or_callback(ListMeta.builder()).build()
             return self._set("metadata", value)
 
         def reason(self, value: Optional[str]) -> Self:
@@ -1444,9 +1906,15 @@ class Status(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["Status", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use Status.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     api_version: Annotated[
         Optional[Literal["v1"]],
@@ -1497,16 +1965,24 @@ class Status(BaseModel):
 
 class WatchEvent(BaseModel):
     class Builder(BaseBuilder):
+        @property
+        def base_class(self) -> Type["WatchEvent"]:
+            return WatchEvent
+
         def build(self) -> "WatchEvent":
             return WatchEvent(**self._attrs)
 
+        """  """
+
         def object(
             self,
-            value_or_callback: Union[RawExtension, Callable[[Type[RawExtension]], RawExtension]],
+            value_or_callback: Union[
+                RawExtension, Callable[[RawExtension.Builder], RawExtension.Builder]
+            ],
         ) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback(RawExtension)
+                value = value_or_callback(RawExtension.builder()).build()
             return self._set("object", value)
 
         def type(self, value: str) -> Self:
@@ -1516,9 +1992,15 @@ class WatchEvent(BaseModel):
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["WatchEvent", Builder]):
+        def __init__(self):
+            raise NotImplementedError(
+                "This class is not meant to be instantiated. Use WatchEvent.list_builder() instead."
+            )
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
 
     object: Annotated[
         RawExtension,

--- a/cloudcoil/codegen/generator.py
+++ b/cloudcoil/codegen/generator.py
@@ -842,9 +842,10 @@ def generate(config: ModelConfig):
         "typing.Callable",
         "typing.Union",
         "typing.Type",
+        "typing.cast",
         "cloudcoil.pydantic.BaseBuilder",
         "cloudcoil.pydantic.BaseModel",
-        "cloudcoil.pydantic.ListBuilder",
+        "cloudcoil.pydantic.GenericListBuilder",
         "cloudcoil.pydantic.Self",
     ]
     if config.mode == "resource":

--- a/cloudcoil/codegen/templates/pydantic_v2/BaseModel.jinja2
+++ b/cloudcoil/codegen/templates/pydantic_v2/BaseModel.jinja2
@@ -14,20 +14,28 @@ class {{ class_name }}(BaseModel):{% if comment is defined %}  # {{ comment }}{%
     {{ description | indent(4) }}
     """
 {%- endif %}
+
     class Builder(BaseBuilder):
+
+        @property
+        def base_class(self) -> Type["{{ class_name }}"]:
+            return {{ class_name }}
             
         def build(self) -> "{{ class_name }}":
             return {{ class_name }}(**self._attrs)
+    
 
     {%- for field in fields %}
+
         {%- set field_setter_name = field.name if field.name != "build" else "build_" %}
         {%- if field.data_type.data_types and field.data_type.data_types[0].is_list  %}
         {%- set item_type = field.data_type.data_types[0].data_types[0] %}
         {%- if item_type.reference is not none %}
-        def {{ field_setter_name }}(self, value_or_callback: Union[{{ field.type_hint }}, Callable[[Type[{{ item_type.type_hint }}]], List[{{ item_type.type_hint }}]]]) -> Self:
+        """ {{ item_type.data_type }} """
+        def {{ field_setter_name }}(self, value_or_callback: Union[{{ field.type_hint }}, Callable[[GenericListBuilder[{{ item_type.type_hint }}, {{ item_type.type_hint }}.Builder]], GenericListBuilder[{{ item_type.type_hint }}, {{ item_type.type_hint }}.Builder]]]) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback({{ item_type.type_hint }})
+                value = value_or_callback({{ item_type.type_hint }}.list_builder()).build()
             return self._set("{{ field.name }}", value)
         {%- else %}
         def {{ field_setter_name }}(self, value: {{ field.type_hint }}) -> Self:
@@ -35,10 +43,12 @@ class {{ class_name }}(BaseModel):{% if comment is defined %}  # {{ comment }}{%
         {%- endif %}
         {%- else %}
         {%- if field.data_type.reference is not none %}
-        def {{ field_setter_name }}(self, value_or_callback: Union[{{ field.type_hint }}, Callable[[Type[{{ field.data_type.type_hint }}]], {{ field.data_type.type_hint }}]]) -> Self:
+        """ {{ field.data_type.data_types[0] }} """
+
+        def {{ field_setter_name }}(self, value_or_callback: Union[{{ field.type_hint }}, Callable[[{{ field.data_type.type_hint }}.Builder], {{ field.data_type.type_hint }}.Builder]]) -> Self:
             value = value_or_callback
             if callable(value_or_callback):
-                value = value_or_callback({{ field.data_type.type_hint }})
+                value = value_or_callback({{ field.data_type.type_hint }}.builder()).build()
             return self._set("{{ field.name }}", value)
         {%- else %}
         def {{ field_setter_name }}(self, value: {{ field.type_hint }}) -> Self:
@@ -51,9 +61,15 @@ class {{ class_name }}(BaseModel):{% if comment is defined %}  # {{ comment }}{%
     def builder(cls) -> Builder:
         return cls.Builder()
 
+    class ListBuilder(GenericListBuilder["{{class_name}}", Builder]):
+        def __init__(self):
+            raise NotImplementedError("This class is not meant to be instantiated. Use {{ class_name }}.list_builder() instead.")
+
     @classmethod
-    def list_builder(cls) -> ListBuilder[Self]:
-        return ListBuilder[cls]()  # type: ignore[valid-type]
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
+    
+    
 
 
 {%- if not fields and not description %}

--- a/cloudcoil/codegen/templates/pydantic_v2/RootModel.jinja2
+++ b/cloudcoil/codegen/templates/pydantic_v2/RootModel.jinja2
@@ -1,0 +1,80 @@
+{%- macro get_type_hint(_fields) -%}
+{%- if _fields -%}
+{#There will only ever be a single field for RootModel#}
+{{- _fields[0].type_hint}}
+{%- endif -%}
+{%- endmacro -%}
+
+
+{% for decorator in decorators -%}
+{{ decorator }}
+{% endfor -%}
+
+class {{ class_name }}({{ base_class }}{%- if fields -%}[{{get_type_hint(fields)}}]{%- endif -%}):{% if comment is defined %}  # {{ comment }}{% endif %}
+{%- if description %}
+    """
+    {{ description | indent(4) }}
+    """
+{%- endif %}
+
+{%- if config %}
+{%- filter indent(4) %}
+{% include 'ConfigDict.jinja2' %}
+{%- endfilter %}
+{%- endif %}
+{%- if not fields and not description %}
+    class Builder(BaseModel):
+        @property
+        def base_class(self) -> Type["{{ class_name }}"]:
+            return {{ class_name }}
+        def build(self) -> "{{ class_name }}":
+            return {{ class_name }}()
+{%- else %}
+    {%- set field = fields[0] %}
+    class Builder(BaseModel):
+        _value: {{ field.type_hint }} | None = None
+        @property
+        def base_class(self) -> Type["{{ class_name }}"]:
+            return {{ class_name }}
+        def root(self, value: {{ field.type_hint }}) -> Self:
+            self._value = value
+            return self
+
+        def __call__(self, value: {{ field.type_hint }}) -> Self:
+            self._value = value
+            return self
+
+        def build(self) -> "{{ class_name }}":
+            value = cast({{ field.type_hint }}, self._value)
+            return {{ class_name }}(value)
+    {%- if not field.annotated and field.field %}
+    root: {{ field.type_hint }} = {{ field.field }}
+    {%- else %}
+    {%- if field.annotated %}
+    root: {{ field.annotated }}
+    {%- else %}
+    root: {{ field.type_hint }}
+    {%- endif %}
+    {%- if not (field.required or (field.represented_default == 'None' and field.strip_default_none))
+            %} = {{ field.represented_default }}
+    {%- endif -%}
+    {%- endif %}
+    {%- if field.docstring %}
+    """
+    {{ field.docstring | indent(4) }}
+    """
+    {%- endif %}
+{%- endif %}
+
+    @classmethod
+    def builder(cls) -> Builder:
+        return cls.Builder()
+
+    class ListBuilder(GenericListBuilder["{{class_name}}", Builder]):
+        def __init__(self):
+            raise NotImplementedError("This class is not meant to be instantiated. Use {{ class_name }}.list_builder() instead.")
+
+    @classmethod
+    def list_builder(cls) -> ListBuilder:
+        return GenericListBuilder[cls, cls.Builder]()  # type: ignore
+

--- a/cloudcoil/pydantic.py
+++ b/cloudcoil/pydantic.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Callable, Dict, Generic, List, Type, TypeVar
+from typing import Any, Callable, Dict, Generic, List, TypeVar
 
 if sys.version_info >= (3, 11):
     from typing import Self as Self
@@ -29,17 +29,17 @@ class BaseBuilder(pydantic.BaseModel):
         return builder
 
 
-class ListBuilder(pydantic.BaseModel, Generic[T]):
+class GenericListBuilder(pydantic.BaseModel, Generic[T, TBuilder]):
     _list: List[T] = []
 
     @property
-    def resource_class(self) -> type[T]:
+    def base_class(self) -> type[T]:
         return self.__pydantic_generic_metadata__["args"][0]
 
-    def add(self, value_or_callback: Callable[[Type[T]], T] | T) -> "Self":
+    def add(self, value_or_callback: Callable[[TBuilder], TBuilder] | T) -> "Self":
         output = self.__class__()
         if callable(value_or_callback):
-            value = value_or_callback(self.resource_class)
+            value = value_or_callback(self.base_class.builder()).build()  # type: ignore
         else:
             value = value_or_callback
         output._list = self._list + [value]

--- a/tests/test_fluent.py
+++ b/tests/test_fluent.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from cloudcoil.apimachinery import APIResource, APIResourceList
 
 
@@ -33,28 +31,16 @@ def test_builder_immutability():
 def test_list_builder():
     resources = APIResource.list_builder()
     resources = resources.add(
-        lambda cls: cls.builder()
-        .name("pods")
+        lambda cls: cls.name("pods")
         .kind("Pod")
         .namespaced(True)
         .singular_name("pod")
         .verbs(["get", "list"])
-        .build()
-    )
-    resources = resources.add(
-        lambda cls: cls(
-            name="services",
-            kind="Service",
-            namespaced=True,
-            singular_name="service",
-            verbs=["get", "list"],
-        )
     )
 
     built = resources.build()
-    assert len(built) == 2
+    assert len(built) == 1
     assert built[0].name == "pods"
-    assert built[1].name == "services"
 
 
 def test_complex_builder():
@@ -62,22 +48,19 @@ def test_complex_builder():
         APIResourceList.builder()
         .group_version("v1")
         .resources(
-            lambda cls: [
-                cls.builder()
-                .name("pods")
+            lambda resources: resources.add(
+                lambda cls: cls.name("pods")
                 .kind("Pod")
                 .namespaced(True)
                 .singular_name("pod")
                 .verbs(["get", "list"])
-                .build(),
-                cls.builder()
-                .name("services")
+            ).add(
+                lambda cls: cls.name("services")
                 .kind("Service")
                 .namespaced(True)
                 .singular_name("service")
                 .verbs(["get", "list"])
-                .build(),
-            ]
+            )
         )
         .build()
     )
@@ -89,23 +72,22 @@ def test_complex_builder():
 
 
 def test_list_callback():
-    def create_resources(cls: type[APIResource]) -> List[APIResource]:
-        return [
-            cls.builder()
-            .name("pods")
+    def create_resources(
+        resources: APIResource.ListBuilder,
+    ) -> APIResource.ListBuilder:
+        return resources.add(
+            lambda cls: cls.name("pods")
             .kind("Pod")
             .namespaced(True)
             .singular_name("pod")
             .verbs(["get", "list"])
-            .build(),
-            cls.builder()
-            .name("services")
+        ).add(
+            lambda cls: cls.name("services")
             .kind("Service")
             .namespaced(True)
             .singular_name("service")
             .verbs(["get", "list"])
-            .build(),
-        ]
+        )
 
     api_list = APIResourceList.builder().group_version("v1").resources(create_resources).build()
 

--- a/uv.lock
+++ b/uv.lock
@@ -185,10 +185,10 @@ name = "cloudcoil"
 version = "0.1.0.dev0"
 source = { editable = "." }
 dependencies = [
-    { name = "cloudcoil-models-kubernetes", version = "1.29.12.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
-    { name = "cloudcoil-models-kubernetes", version = "1.30.8.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-30' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
-    { name = "cloudcoil-models-kubernetes", version = "1.31.4.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
-    { name = "cloudcoil-models-kubernetes", version = "1.32.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra != 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.29.12.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.30.8.5", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-30' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.31.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.32.0.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra != 'extra-9-cloudcoil-kubernetes-1-31')" },
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -197,32 +197,32 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
-    { name = "cloudcoil-models-kubernetes", version = "1.29.12.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
-    { name = "cloudcoil-models-kubernetes", version = "1.30.8.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-30' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
-    { name = "cloudcoil-models-kubernetes", version = "1.31.4.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
-    { name = "cloudcoil-models-kubernetes", version = "1.32.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra != 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.29.12.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.30.8.5", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-30' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.31.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.32.0.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra != 'extra-9-cloudcoil-kubernetes-1-31')" },
 ]
 codegen = [
     { name = "datamodel-code-generator", extra = ["http"] },
     { name = "ruff" },
 ]
 kubernetes = [
-    { name = "cloudcoil-models-kubernetes", version = "1.29.12.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
-    { name = "cloudcoil-models-kubernetes", version = "1.30.8.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-30' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
-    { name = "cloudcoil-models-kubernetes", version = "1.31.4.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
-    { name = "cloudcoil-models-kubernetes", version = "1.32.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra != 'extra-9-cloudcoil-kubernetes-1-31')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.29.12.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.30.8.5", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-30' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.31.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.32.0.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra != 'extra-9-cloudcoil-kubernetes-1-31')" },
 ]
 kubernetes-1-29 = [
-    { name = "cloudcoil-models-kubernetes", version = "1.29.12.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "cloudcoil-models-kubernetes", version = "1.29.12.2", source = { registry = "https://pypi.org/simple" } },
 ]
 kubernetes-1-30 = [
-    { name = "cloudcoil-models-kubernetes", version = "1.30.8.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "cloudcoil-models-kubernetes", version = "1.30.8.5", source = { registry = "https://pypi.org/simple" } },
 ]
 kubernetes-1-31 = [
-    { name = "cloudcoil-models-kubernetes", version = "1.31.4.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "cloudcoil-models-kubernetes", version = "1.31.4.4", source = { registry = "https://pypi.org/simple" } },
 ]
 kubernetes-1-32 = [
-    { name = "cloudcoil-models-kubernetes", version = "1.32.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "cloudcoil-models-kubernetes", version = "1.32.0.1", source = { registry = "https://pypi.org/simple" } },
 ]
 test = [
     { name = "pytest" },
@@ -287,7 +287,7 @@ dev = [
 
 [[package]]
 name = "cloudcoil-models-kubernetes"
-version = "1.29.12.0"
+version = "1.29.12.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '4.0'",
@@ -298,14 +298,14 @@ resolution-markers = [
 dependencies = [
     { name = "cloudcoil", marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/3c/cae8aaf0f97d7889c715d5626105c1b097a4fcd89404f1fe2fa36a5c7724/cloudcoil_models_kubernetes-1.29.12.0.tar.gz", hash = "sha256:f7e651534c28435b770326c60b2d4224c63278a0eb9c36429841d73bc055f3b2", size = 197384 }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/2b/4bac106e92ee8307e2731cc1bf397576346cefcf2a0e52c13006adefce62/cloudcoil_models_kubernetes-1.29.12.2.tar.gz", hash = "sha256:75f12507ee6d7493020e5de8b5d588d3599091061c000d84d92aa2e607f8f30f", size = 197414 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/a7/3706345339817ee208d8be1c9998ec3eb5e316a78eee16aacae09d1b2579/cloudcoil_models_kubernetes-1.29.12.0-py3-none-any.whl", hash = "sha256:780e296c2c00cfb9091ebac1da5c632e9d05b95cabfa1204411463aaf6ff77c2", size = 177362 },
+    { url = "https://files.pythonhosted.org/packages/a4/ee/de514b5cad920966142060b381aa2d70302fd8769c56d150ac056a93f90d/cloudcoil_models_kubernetes-1.29.12.2-py3-none-any.whl", hash = "sha256:47c94d543898a01f2725ac65ec978cd6d6ebdec12862a45bfd42dfba78a13d89", size = 177321 },
 ]
 
 [[package]]
 name = "cloudcoil-models-kubernetes"
-version = "1.30.8.3"
+version = "1.30.8.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '4.0'",
@@ -316,14 +316,14 @@ resolution-markers = [
 dependencies = [
     { name = "cloudcoil", marker = "extra == 'extra-9-cloudcoil-kubernetes-1-30' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/31/27f74aa62df2128b72999dcce5d98d6ad56055b1927b44a7eeb1171ca796/cloudcoil_models_kubernetes-1.30.8.3.tar.gz", hash = "sha256:e65eb7267ca306d74b2c06e5cc7b6a3b1bc3ff953a5704de7c44cca6bb9b168e", size = 209081 }
+sdist = { url = "https://files.pythonhosted.org/packages/59/40/f385f9c323af65ffce98512bd8d573e65397bd59a9d65b8a2991fedbac3d/cloudcoil_models_kubernetes-1.30.8.5.tar.gz", hash = "sha256:113c49f5edd1960dc492f48c8906b8ac0eb97d9c869d026eb6f8c8a7ae7e16b5", size = 209145 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/79/bc3e0a6971edfdb921b833cb8a69489ddd6442068cbbdfca6c26e371569e/cloudcoil_models_kubernetes-1.30.8.3-py3-none-any.whl", hash = "sha256:3b421246aa0db08a89ede19287f1599f9fef1fec5105252b0c11189f27d16137", size = 188892 },
+    { url = "https://files.pythonhosted.org/packages/31/8c/2e21f2d6e791ebdfbd868e66995a2fdf1be1a681baee9d7ef06bce7f6fd3/cloudcoil_models_kubernetes-1.30.8.5-py3-none-any.whl", hash = "sha256:d13d5ee3dcdd127bd750ba5a91ee963553319f607919c90418e5aab4d9b5c111", size = 188867 },
 ]
 
 [[package]]
 name = "cloudcoil-models-kubernetes"
-version = "1.31.4.3"
+version = "1.31.4.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '4.0'",
@@ -334,14 +334,14 @@ resolution-markers = [
 dependencies = [
     { name = "cloudcoil", marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/1c/aa205d980ce73a058be02784aff5194233783531b95f8b7114c15a45dd2d/cloudcoil_models_kubernetes-1.31.4.3.tar.gz", hash = "sha256:0d513f1c2e47f023bff01a94d9897cbd3ca9093dc603dcd1d7ef428968c6ad86", size = 214679 }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ee/453bafc8b9c7dc3f6fc347c826ff7fe1f58de4641bb072d4e2120931ed28/cloudcoil_models_kubernetes-1.31.4.4.tar.gz", hash = "sha256:60946a3432fbd61a3f6c2ff0101c45c41c845e8574e711309e7ca60fd06a524f", size = 214721 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/aa/4473718fb41c61c28151d75f594cc070e6b04476aa60f3971e7595eddc4b/cloudcoil_models_kubernetes-1.31.4.3-py3-none-any.whl", hash = "sha256:6620c8f4f2daf714c5301631e8fdac424045cf3e19051f68463ac6b77707a18a", size = 196762 },
+    { url = "https://files.pythonhosted.org/packages/92/a6/aab8d91bc2eeed7d7373e4b67dcdb4dc1c61d2c2532eddeb06bb4316af1d/cloudcoil_models_kubernetes-1.31.4.4-py3-none-any.whl", hash = "sha256:5341fa6a27a199b839546c3caf5bcf39dcb1b939be82daff2a2319b35198692e", size = 196734 },
 ]
 
 [[package]]
 name = "cloudcoil-models-kubernetes"
-version = "1.32.0.0"
+version = "1.32.0.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '4.0'",
@@ -352,9 +352,9 @@ resolution-markers = [
 dependencies = [
     { name = "cloudcoil", marker = "extra == 'extra-9-cloudcoil-kubernetes-1-32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra != 'extra-9-cloudcoil-kubernetes-1-31')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/5e/20c20c3c29727fb73b0287ea449e9f7d593ce6182847ecbef3e5c28e5a73/cloudcoil_models_kubernetes-1.32.0.0.tar.gz", hash = "sha256:4c32dc6df9ad6e0d2cf2ddcec5c08e1a4216225bc2dd0e34ce72eb213bc7a8ae", size = 212680 }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/31/15dee254af75866eeb01227ea27f2a021325209ae4f63262aa8584f24314/cloudcoil_models_kubernetes-1.32.0.1.tar.gz", hash = "sha256:e81beeca258b919eb0591564fc344f25762dc097b27acb3556b8ab6acf7f5290", size = 212705 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/40/d019bf25f0137ef74b587fbaed6b23e6f191c51cde0f8a602a370918b2d5/cloudcoil_models_kubernetes-1.32.0.0-py3-none-any.whl", hash = "sha256:7bfdfabc0a33464daab4917f477793cacc456ee78f8c57740c81b0817ada0e51", size = 198119 },
+    { url = "https://files.pythonhosted.org/packages/c0/eb/aad4fc7080c6b04a7909a279a9881cf097fb99ff0e7bc3f261ed3c7e141b/cloudcoil_models_kubernetes-1.32.0.1-py3-none-any.whl", hash = "sha256:37c21e3a57dbdd465550a6f56c62c0ce910b54dc576bce4ce37841af36392308", size = 198109 },
 ]
 
 [[package]]
@@ -432,7 +432,7 @@ toml = [
 
 [[package]]
 name = "datamodel-code-generator"
-version = "0.26.4"
+version = "0.26.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete" },
@@ -446,9 +446,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "toml", marker = "python_full_version < '3.11' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/d3/4989ef484c41c35f45a16b54ffc25ffb4972d2fefde576a604f1c8c0675d/datamodel_code_generator-0.26.4.tar.gz", hash = "sha256:9881124fec15655a3a635808ea5ded63afb0540c0c402998070ccf60a9dab225", size = 92241 }
+sdist = { url = "https://files.pythonhosted.org/packages/63/e4/53153452235a387112df40f67aaf24072d4b5e33aa7bb385004f4c4baf38/datamodel_code_generator-0.26.5.tar.gz", hash = "sha256:c4a94a7dbf7972129882732d9bcee44c9ae090f57c82edd58d237b9d48c40dd0", size = 92586 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/e7/66a7c16bfbf5596e9e556fa9841d3cb3fb61ff79026b084328a9c7e04a00/datamodel_code_generator-0.26.4-py3-none-any.whl", hash = "sha256:95bdaa91fe87a8c369b1c9147bb2ef2eead918964270451e6223235131974098", size = 114595 },
+    { url = "https://files.pythonhosted.org/packages/5a/d8/ead3e857d4048947fe92a731d6b1f257dcb267cc8b8918d3b72598c9b728/datamodel_code_generator-0.26.5-py3-none-any.whl", hash = "sha256:e32f986b9914a2b45093947043aa0192d704650be93151f78acf5c95676601ce", size = 114982 },
 ]
 
 [package.optional-dependencies]
@@ -507,11 +507,11 @@ wheels = [
 
 [[package]]
 name = "executing"
-version = "2.1.0"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/e3/7d45f492c2c4a0e8e0fad57d081a7c8a0286cdd86372b070cca1ec0caa1e/executing-2.1.0.tar.gz", hash = "sha256:8ea27ddd260da8150fa5a708269c4a10e76161e2496ec3e587da9e3c0fe4b9ab", size = 977485 }
+sdist = { url = "https://files.pythonhosted.org/packages/91/50/a9d80c47ff289c611ff12e63f7c5d13942c65d68125160cefd768c73e6e4/executing-2.2.0.tar.gz", hash = "sha256:5d108c028108fe2551d1a7b2e8b713341e2cb4fc0aa7dcf966fa4327a5226755", size = 978693 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/fd/afcd0496feca3276f509df3dbd5dae726fcc756f1a08d9e25abe1733f962/executing-2.1.0-py2.py3-none-any.whl", hash = "sha256:8d63781349375b5ebccc3142f4b30350c0cd9c79f921cde38be2be4637e98eaf", size = 25805 },
+    { url = "https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl", hash = "sha256:11387150cad388d62750327a53d3339fad4888b39a6fe233c3afbb54ecffd3aa", size = 26702 },
 ]
 
 [[package]]
@@ -537,14 +537,14 @@ wheels = [
 
 [[package]]
 name = "griffe"
-version = "1.5.4"
+version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/9b/0bc9d53ed6628aae43223dd3c081637da54f66ed17a8c1d9fd36ee5da244/griffe-1.5.4.tar.gz", hash = "sha256:073e78ad3e10c8378c2f798bd4ef87b92d8411e9916e157fd366a17cc4fd4e52", size = 389376 }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/74/cd35a98cb11f79de0581e8e1e6fbd738aeeed1f2d90e9b5106728b63f5f7/griffe-1.5.5.tar.gz", hash = "sha256:35ee5b38b93d6a839098aad0f92207e6ad6b70c3e8866c08ca669275b8cba585", size = 391124 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/29/d0f156c076ec71eb485e70cbcde4872e3c045cda965a48d1d938aa3d9f76/griffe-1.5.4-py3-none-any.whl", hash = "sha256:ed33af890586a5bebc842fcb919fc694b3dc1bc55b7d9e0228de41ce566b4a1d", size = 128102 },
+    { url = "https://files.pythonhosted.org/packages/1f/88/52c9422bc853cd7c2b6122090e887d17b5fad29b67f930e4277c9c557357/griffe-1.5.5-py3-none-any.whl", hash = "sha256:2761b1e8876c6f1f9ab1af274df93ea6bbadd65090de5f38f4cb5cc84897c7dd", size = 128221 },
 ]
 
 [[package]]
@@ -780,16 +780,16 @@ wheels = [
 
 [[package]]
 name = "mkdocs-autorefs"
-version = "1.2.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "markupsafe" },
     { name = "mkdocs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/ae/0f1154c614d6a8b8a36fff084e5b82af3a15f7d2060cf0dcdb1c53297a71/mkdocs_autorefs-1.2.0.tar.gz", hash = "sha256:a86b93abff653521bda71cf3fc5596342b7a23982093915cb74273f67522190f", size = 40262 }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/18/fb1e17fb705228b51bf7b2f791adaf83c0fa708e51bbc003411ba48ae21e/mkdocs_autorefs-1.3.0.tar.gz", hash = "sha256:6867764c099ace9025d6ac24fd07b85a98335fbd30107ef01053697c8f46db61", size = 42597 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/26/4d39d52ea2219604053a4d05b98e90d6a335511cc01806436ec4886b1028/mkdocs_autorefs-1.2.0-py3-none-any.whl", hash = "sha256:d588754ae89bd0ced0c70c06f58566a4ee43471eeeee5202427da7de9ef85a2f", size = 16522 },
+    { url = "https://files.pythonhosted.org/packages/f4/4a/960c441950f98becfa5dd419adab20274939fd575ab848aee2c87e3599ac/mkdocs_autorefs-1.3.0-py3-none-any.whl", hash = "sha256:d180f9778a04e78b7134e31418f238bba56f56d6a8af97873946ff661befffb3", size = 17642 },
 ]
 
 [[package]]
@@ -808,7 +808,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.5.49"
+version = "9.5.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -823,9 +823,9 @@ dependencies = [
     { name = "regex" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/14/8daeeecee2e25bd84239a843fdcb92b20db88ebbcb26e0d32f414ca54a22/mkdocs_material-9.5.49.tar.gz", hash = "sha256:3671bb282b4f53a1c72e08adbe04d2481a98f85fed392530051f80ff94a9621d", size = 3949559 }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/16/c48d5a28bc4a67c49808180b6009d4d1b4c0753739ffee3cc37046ab29d7/mkdocs_material-9.5.50.tar.gz", hash = "sha256:ae5fe16f3d7c9ccd05bb6916a7da7420cf99a9ce5e33debd9d40403a090d5825", size = 3923354 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/2d/2dd23a36b48421db54f118bb6f6f733dbe2d5c78fe7867375e48649fd3df/mkdocs_material-9.5.49-py3-none-any.whl", hash = "sha256:c3c2d8176b18198435d3a3e119011922f3e11424074645c24019c2dcf08a360e", size = 8684098 },
+    { url = "https://files.pythonhosted.org/packages/ee/b5/1bf29cd744896ae83bd38c72970782c843ba13e0240b1a85277bd3928637/mkdocs_material-9.5.50-py3-none-any.whl", hash = "sha256:f24100f234741f4d423a9d672a909d859668a4f404796be3cf035f10d6050385", size = 8645274 },
 ]
 
 [[package]]
@@ -985,14 +985,14 @@ wheels = [
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.48"
+version = "3.0.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/4f/feb5e137aff82f7c7f3248267b97451da3644f6cdc218edfe549fb354127/prompt_toolkit-3.0.48.tar.gz", hash = "sha256:d6623ab0477a80df74e646bdbc93621143f5caf104206aa29294d53de1a03d90", size = 424684 }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/e1/bd15cb8ffdcfeeb2bdc215de3c3cffca11408d829e4b8416dcfe71ba8854/prompt_toolkit-3.0.50.tar.gz", hash = "sha256:544748f3860a2623ca5cd6d2795e7a14f3d0e1c3c9728359013f79877fc89bab", size = 429087 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/6a/fd08d94654f7e67c52ca30523a178b3f8ccc4237fce4be90d39c938a831a/prompt_toolkit-3.0.48-py3-none-any.whl", hash = "sha256:f49a827f90062e411f1ce1f854f2aedb3c23353244f8108b89283587397ac10e", size = 386595 },
+    { url = "https://files.pythonhosted.org/packages/e4/ea/d836f008d33151c7a1f62caf3d8dd782e4d15f6a43897f64480c2b8de2ad/prompt_toolkit-3.0.50-py3-none-any.whl", hash = "sha256:9b6427eb19e479d98acff65196a307c555eb567989e6d88ebbb1b509d9779198", size = 387816 },
 ]
 
 [[package]]
@@ -1015,16 +1015,16 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.10.4"
+version = "2.10.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/7e/fb60e6fee04d0ef8f15e4e01ff187a196fa976eb0f0ab524af4599e5754c/pydantic-2.10.4.tar.gz", hash = "sha256:82f12e9723da6de4fe2ba888b5971157b3be7ad914267dea8f05f82b28254f06", size = 762094 }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/c7/ca334c2ef6f2e046b1144fe4bb2a5da8a4c574e7f2ebf7e16b34a6a2fa92/pydantic-2.10.5.tar.gz", hash = "sha256:278b38dbbaec562011d659ee05f63346951b3a248a6f3642e1bc68894ea2b4ff", size = 761287 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/26/3e1bbe954fde7ee22a6e7d31582c642aad9e84ffe4b5fb61e63b87cd326f/pydantic-2.10.4-py3-none-any.whl", hash = "sha256:597e135ea68be3a37552fb524bc7d0d66dcf93d395acd93a00682f1efcb8ee3d", size = 431765 },
+    { url = "https://files.pythonhosted.org/packages/58/26/82663c79010b28eddf29dcdd0ea723439535fa917fce5905885c0e9ba562/pydantic-2.10.5-py3-none-any.whl", hash = "sha256:4dd4e322dbe55472cb7ca7e73f4b63574eecccf2835ffa2af9021ce113c83c53", size = 431426 },
 ]
 
 [package.optional-dependencies]
@@ -1109,24 +1109,24 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.0"
+version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/c0/9c9832e5be227c40e1ce774d493065f83a91d6430baa7e372094e9683a45/pygments-2.19.0.tar.gz", hash = "sha256:afc4146269910d4bdfabcd27c24923137a74d562a23a320a41a55ad303e19783", size = 4967733 }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/dc/fde3e7ac4d279a331676829af4afafd113b34272393d73f610e8f0329221/pygments-2.19.0-py3-none-any.whl", hash = "sha256:4755e6e64d22161d5b61432c0600c923c5927214e7c956e31c23923c89251a9b", size = 1225305 },
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
 ]
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.13"
+version = "10.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/87/4998d1aac5afea5b081238a609d9814f4c33cd5c7123503276d1105fb6a9/pymdown_extensions-10.13.tar.gz", hash = "sha256:e0b351494dc0d8d14a1f52b39b1499a00ef1566b4ba23dc74f1eba75c736f5dd", size = 843302 }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/24/f7a412dc1630b1a6d7b288e7c736215ce878ee4aad24359f7f67b53bbaa9/pymdown_extensions-10.14.1.tar.gz", hash = "sha256:b65801996a0cd4f42a3110810c306c45b7313c09b0610a6f773730f2a9e3c96b", size = 845243 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/7f/46c7122186759350cf523c71d29712be534f769f073a1d980ce8f095072c/pymdown_extensions-10.13-py3-none-any.whl", hash = "sha256:80bc33d715eec68e683e04298946d47d78c7739e79d808203df278ee8ef89428", size = 264108 },
+    { url = "https://files.pythonhosted.org/packages/09/fb/79a8d27966e90feeeb686395c8b1bff8221727abcbd80d2485841393a955/pymdown_extensions-10.14.1-py3-none-any.whl", hash = "sha256:637951cbfbe9874ba28134fb3ce4b8bcadd6aca89ac4998ec29dcbafd554ae08", size = 264283 },
 ]
 
 [[package]]
@@ -1148,14 +1148,14 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.25.1"
+version = "0.25.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/04/0477a4bdd176ad678d148c075f43620b3f7a060ff61c7da48500b1fa8a75/pytest_asyncio-0.25.1.tar.gz", hash = "sha256:79be8a72384b0c917677e00daa711e07db15259f4d23203c59012bcd989d4aee", size = 53760 }
+sdist = { url = "https://files.pythonhosted.org/packages/72/df/adcc0d60f1053d74717d21d58c0048479e9cab51464ce0d2965b086bd0e2/pytest_asyncio-0.25.2.tar.gz", hash = "sha256:3f8ef9a98f45948ea91a0ed3dc4268b5326c0e7bce73892acc654df4262ad45f", size = 53950 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/fb/efc7226b384befd98d0e00d8c4390ad57f33c8fde00094b85c5e07897def/pytest_asyncio-0.25.1-py3-none-any.whl", hash = "sha256:c84878849ec63ff2ca509423616e071ef9cd8cc93c053aa33b5b8fb70a990671", size = 19357 },
+    { url = "https://files.pythonhosted.org/packages/61/d8/defa05ae50dcd6019a95527200d3b3980043df5aa445d40cb0ef9f7f98ab/pytest_asyncio-0.25.2-py3-none-any.whl", hash = "sha256:0d0bb693f7b99da304a0634afc0a4b19e49d5e0de2d670f38dc4bfa5727c5075", size = 19400 },
 ]
 
 [[package]]
@@ -1352,27 +1352,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.8.6"
+version = "0.9.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/00/089db7890ea3be5709e3ece6e46408d6f1e876026ec3fd081ee585fef209/ruff-0.8.6.tar.gz", hash = "sha256:dcad24b81b62650b0eb8814f576fc65cfee8674772a6e24c9b747911801eeaa5", size = 3473116 }
+sdist = { url = "https://files.pythonhosted.org/packages/80/63/77ecca9d21177600f551d1c58ab0e5a0b260940ea7312195bd2a4798f8a8/ruff-0.9.2.tar.gz", hash = "sha256:b5eceb334d55fae5f316f783437392642ae18e16dcf4f1858d55d3c2a0f8f5d0", size = 3553799 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/28/aa07903694637c2fa394a9f4fe93cf861ad8b09f1282fa650ef07ff9fe97/ruff-0.8.6-py3-none-linux_armv6l.whl", hash = "sha256:defed167955d42c68b407e8f2e6f56ba52520e790aba4ca707a9c88619e580e3", size = 10628735 },
-    { url = "https://files.pythonhosted.org/packages/2b/43/827bb1448f1fcb0fb42e9c6edf8fb067ca8244923bf0ddf12b7bf949065c/ruff-0.8.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:54799ca3d67ae5e0b7a7ac234baa657a9c1784b48ec954a094da7c206e0365b1", size = 10386758 },
-    { url = "https://files.pythonhosted.org/packages/df/93/fc852a81c3cd315b14676db3b8327d2bb2d7508649ad60bfdb966d60738d/ruff-0.8.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e88b8f6d901477c41559ba540beeb5a671e14cd29ebd5683903572f4b40a9807", size = 10007808 },
-    { url = "https://files.pythonhosted.org/packages/94/e9/e0ed4af1794335fb280c4fac180f2bf40f6a3b859cae93a5a3ada27325ae/ruff-0.8.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0509e8da430228236a18a677fcdb0c1f102dd26d5520f71f79b094963322ed25", size = 10861031 },
-    { url = "https://files.pythonhosted.org/packages/82/68/da0db02f5ecb2ce912c2bef2aa9fcb8915c31e9bc363969cfaaddbc4c1c2/ruff-0.8.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:91a7ddb221779871cf226100e677b5ea38c2d54e9e2c8ed847450ebbdf99b32d", size = 10388246 },
-    { url = "https://files.pythonhosted.org/packages/ac/1d/b85383db181639019b50eb277c2ee48f9f5168f4f7c287376f2b6e2a6dc2/ruff-0.8.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:248b1fb3f739d01d528cc50b35ee9c4812aa58cc5935998e776bf8ed5b251e75", size = 11424693 },
-    { url = "https://files.pythonhosted.org/packages/ac/b7/30bc78a37648d31bfc7ba7105b108cb9091cd925f249aa533038ebc5a96f/ruff-0.8.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:bc3c083c50390cf69e7e1b5a5a7303898966be973664ec0c4a4acea82c1d4315", size = 12141921 },
-    { url = "https://files.pythonhosted.org/packages/60/b3/ee0a14cf6a1fbd6965b601c88d5625d250b97caf0534181e151504498f86/ruff-0.8.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:52d587092ab8df308635762386f45f4638badb0866355b2b86760f6d3c076188", size = 11692419 },
-    { url = "https://files.pythonhosted.org/packages/ef/d6/c597062b2931ba3e3861e80bd2b147ca12b3370afc3889af46f29209037f/ruff-0.8.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:61323159cf21bc3897674e5adb27cd9e7700bab6b84de40d7be28c3d46dc67cf", size = 12981648 },
-    { url = "https://files.pythonhosted.org/packages/68/84/21f578c2a4144917985f1f4011171aeff94ab18dfa5303ac632da2f9af36/ruff-0.8.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ae4478b1471fc0c44ed52a6fb787e641a2ac58b1c1f91763bafbc2faddc5117", size = 11251801 },
-    { url = "https://files.pythonhosted.org/packages/6c/aa/1ac02537c8edeb13e0955b5db86b5c050a1dcba54f6d49ab567decaa59c1/ruff-0.8.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0c000a471d519b3e6cfc9c6680025d923b4ca140ce3e4612d1a2ef58e11f11fe", size = 10849857 },
-    { url = "https://files.pythonhosted.org/packages/eb/00/020cb222252d833956cb3b07e0e40c9d4b984fbb2dc3923075c8f944497d/ruff-0.8.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:9257aa841e9e8d9b727423086f0fa9a86b6b420fbf4bf9e1465d1250ce8e4d8d", size = 10470852 },
-    { url = "https://files.pythonhosted.org/packages/00/56/e6d6578202a0141cd52299fe5acb38b2d873565f4670c7a5373b637cf58d/ruff-0.8.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:45a56f61b24682f6f6709636949ae8cc82ae229d8d773b4c76c09ec83964a95a", size = 10972997 },
-    { url = "https://files.pythonhosted.org/packages/be/31/dd0db1f4796bda30dea7592f106f3a67a8f00bcd3a50df889fbac58e2786/ruff-0.8.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:496dd38a53aa173481a7d8866bcd6451bd934d06976a2505028a50583e001b76", size = 11317760 },
-    { url = "https://files.pythonhosted.org/packages/d4/70/cfcb693dc294e034c6fed837fa2ec98b27cc97a26db5d049345364f504bf/ruff-0.8.6-py3-none-win32.whl", hash = "sha256:e169ea1b9eae61c99b257dc83b9ee6c76f89042752cb2d83486a7d6e48e8f764", size = 8799729 },
-    { url = "https://files.pythonhosted.org/packages/60/22/ae6bcaa0edc83af42751bd193138bfb7598b2990939d3e40494d6c00698c/ruff-0.8.6-py3-none-win_amd64.whl", hash = "sha256:f1d70bef3d16fdc897ee290d7d20da3cbe4e26349f62e8a0274e7a3f4ce7a905", size = 9673857 },
-    { url = "https://files.pythonhosted.org/packages/91/f8/3765e053acd07baa055c96b2065c7fab91f911b3c076dfea71006666f5b0/ruff-0.8.6-py3-none-win_arm64.whl", hash = "sha256:7d7fc2377a04b6e04ffe588caad613d0c460eb2ecba4c0ccbbfe2bc973cbc162", size = 9149556 },
+    { url = "https://files.pythonhosted.org/packages/af/b9/0e168e4e7fb3af851f739e8f07889b91d1a33a30fca8c29fa3149d6b03ec/ruff-0.9.2-py3-none-linux_armv6l.whl", hash = "sha256:80605a039ba1454d002b32139e4970becf84b5fee3a3c3bf1c2af6f61a784347", size = 11652408 },
+    { url = "https://files.pythonhosted.org/packages/2c/22/08ede5db17cf701372a461d1cb8fdde037da1d4fa622b69ac21960e6237e/ruff-0.9.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b9aab82bb20afd5f596527045c01e6ae25a718ff1784cb92947bff1f83068b00", size = 11587553 },
+    { url = "https://files.pythonhosted.org/packages/42/05/dedfc70f0bf010230229e33dec6e7b2235b2a1b8cbb2a991c710743e343f/ruff-0.9.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fbd337bac1cfa96be615f6efcd4bc4d077edbc127ef30e2b8ba2a27e18c054d4", size = 11020755 },
+    { url = "https://files.pythonhosted.org/packages/df/9b/65d87ad9b2e3def67342830bd1af98803af731243da1255537ddb8f22209/ruff-0.9.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82b35259b0cbf8daa22a498018e300b9bb0174c2bbb7bcba593935158a78054d", size = 11826502 },
+    { url = "https://files.pythonhosted.org/packages/93/02/f2239f56786479e1a89c3da9bc9391120057fc6f4a8266a5b091314e72ce/ruff-0.9.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8b6a9701d1e371bf41dca22015c3f89769da7576884d2add7317ec1ec8cb9c3c", size = 11390562 },
+    { url = "https://files.pythonhosted.org/packages/c9/37/d3a854dba9931f8cb1b2a19509bfe59e00875f48ade632e95aefcb7a0aee/ruff-0.9.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9cc53e68b3c5ae41e8faf83a3b89f4a5d7b2cb666dff4b366bb86ed2a85b481f", size = 12548968 },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/c7b812bb256c7a1d5553433e95980934ffa85396d332401f6b391d3c4569/ruff-0.9.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:8efd9da7a1ee314b910da155ca7e8953094a7c10d0c0a39bfde3fcfd2a015684", size = 13187155 },
+    { url = "https://files.pythonhosted.org/packages/bd/5a/3c7f9696a7875522b66aa9bba9e326e4e5894b4366bd1dc32aa6791cb1ff/ruff-0.9.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3292c5a22ea9a5f9a185e2d131dc7f98f8534a32fb6d2ee7b9944569239c648d", size = 12704674 },
+    { url = "https://files.pythonhosted.org/packages/be/d6/d908762257a96ce5912187ae9ae86792e677ca4f3dc973b71e7508ff6282/ruff-0.9.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1a605fdcf6e8b2d39f9436d343d1f0ff70c365a1e681546de0104bef81ce88df", size = 14529328 },
+    { url = "https://files.pythonhosted.org/packages/2d/c2/049f1e6755d12d9cd8823242fa105968f34ee4c669d04cac8cea51a50407/ruff-0.9.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c547f7f256aa366834829a08375c297fa63386cbe5f1459efaf174086b564247", size = 12385955 },
+    { url = "https://files.pythonhosted.org/packages/91/5a/a9bdb50e39810bd9627074e42743b00e6dc4009d42ae9f9351bc3dbc28e7/ruff-0.9.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d18bba3d3353ed916e882521bc3e0af403949dbada344c20c16ea78f47af965e", size = 11810149 },
+    { url = "https://files.pythonhosted.org/packages/e5/fd/57df1a0543182f79a1236e82a79c68ce210efb00e97c30657d5bdb12b478/ruff-0.9.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b338edc4610142355ccf6b87bd356729b62bf1bc152a2fad5b0c7dc04af77bfe", size = 11479141 },
+    { url = "https://files.pythonhosted.org/packages/dc/16/bc3fd1d38974f6775fc152a0554f8c210ff80f2764b43777163c3c45d61b/ruff-0.9.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:492a5e44ad9b22a0ea98cf72e40305cbdaf27fac0d927f8bc9e1df316dcc96eb", size = 12014073 },
+    { url = "https://files.pythonhosted.org/packages/47/6b/e4ca048a8f2047eb652e1e8c755f384d1b7944f69ed69066a37acd4118b0/ruff-0.9.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:af1e9e9fe7b1f767264d26b1075ac4ad831c7db976911fa362d09b2d0356426a", size = 12435758 },
+    { url = "https://files.pythonhosted.org/packages/c2/40/4d3d6c979c67ba24cf183d29f706051a53c36d78358036a9cd21421582ab/ruff-0.9.2-py3-none-win32.whl", hash = "sha256:71cbe22e178c5da20e1514e1e01029c73dc09288a8028a5d3446e6bba87a5145", size = 9796916 },
+    { url = "https://files.pythonhosted.org/packages/c3/ef/7f548752bdb6867e6939489c87fe4da489ab36191525fadc5cede2a6e8e2/ruff-0.9.2-py3-none-win_amd64.whl", hash = "sha256:c5e1d6abc798419cf46eed03f54f2e0c3adb1ad4b801119dedf23fcaf69b55b5", size = 10773080 },
+    { url = "https://files.pythonhosted.org/packages/0e/4e/33df635528292bd2d18404e4daabcd74ca8a9853b2e1df85ed3d32d24362/ruff-0.9.2-py3-none-win_arm64.whl", hash = "sha256:a1b63fa24149918f8b37cef2ee6fff81f24f0d74b6f0bdc37bc3e1f2143e41c6", size = 10001738 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request includes multiple changes to the `cloudcoil` codebase, focusing on enhancing the builder pattern and improving type handling. The most important changes include modifications to the `BaseModel` and `RootModel` templates, the introduction of `GenericListBuilder`, and updates to the test cases to reflect these changes.

Enhancements to builder pattern and type handling:

* [`cloudcoil/codegen/generator.py`](diffhunk://#diff-e20a70c20872264a870680b7b56b68e61f1bb2e5317c1275afc3a94739cbb218R845-R848): Replaced `ListBuilder` with `GenericListBuilder` and added `typing.cast` to the list of imports.
* [`cloudcoil/codegen/templates/pydantic_v2/BaseModel.jinja2`](diffhunk://#diff-1ec40bf99182f1b718f59e8cc58139f928ed6abe7ef19337a1617e484eb780f2R17-R51): Introduced `base_class` property in the `Builder` class, updated field setter methods to use `GenericListBuilder`, and added a new `ListBuilder` class. [[1]](diffhunk://#diff-1ec40bf99182f1b718f59e8cc58139f928ed6abe7ef19337a1617e484eb780f2R17-R51) [[2]](diffhunk://#diff-1ec40bf99182f1b718f59e8cc58139f928ed6abe7ef19337a1617e484eb780f2R64-R72)
* [`cloudcoil/codegen/templates/pydantic_v2/RootModel.jinja2`](diffhunk://#diff-ebf7423cc5919e1af52dcbbca2cb60935e637bffd776119320d475fa330b7c43R1-R80): Added a macro for type hints, included builder methods, and defined a new `ListBuilder` class.
* [`cloudcoil/pydantic.py`](diffhunk://#diff-ddad3bfbbffa6685083ad01d81217cbb3766f89258c992f700b4c71b5e3bb5eeL2-R2): Introduced `GenericListBuilder` to replace `ListBuilder`, updated the `add` method to use the builder pattern. [[1]](diffhunk://#diff-ddad3bfbbffa6685083ad01d81217cbb3766f89258c992f700b4c71b5e3bb5eeL2-R2) [[2]](diffhunk://#diff-ddad3bfbbffa6685083ad01d81217cbb3766f89258c992f700b4c71b5e3bb5eeL32-R42)

Updates to test cases:

* [`tests/test_fluent.py`](diffhunk://#diff-00518b6a0cf346fc5f025b5d8d0eb51a94686ae1f91d72672b51533a9b59b9d0L1-L2): Removed unnecessary imports, updated test cases to use the new `GenericListBuilder` pattern, and adjusted assertions accordingly. [[1]](diffhunk://#diff-00518b6a0cf346fc5f025b5d8d0eb51a94686ae1f91d72672b51533a9b59b9d0L1-L2) [[2]](diffhunk://#diff-00518b6a0cf346fc5f025b5d8d0eb51a94686ae1f91d72672b51533a9b59b9d0L36-R63) [[3]](diffhunk://#diff-00518b6a0cf346fc5f025b5d8d0eb51a94686ae1f91d72672b51533a9b59b9d0L92-R90)





The previous API was a bit non-ergonomic. Move to builder based fluency.