### PR TITLE
Add missing models and update readme with the new api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ lint:
 
 .PHONY: fix-lint
 fix-lint:
-	uv run --frozen ruff format cloudcoil tests .
-	uv run --frozen ruff check --fix --unsafe-fixes cloudcoil tests .
+	uv run --frozen ruff format cloudcoil tests
+	uv run --frozen ruff check --fix --unsafe-fixes cloudcoil tests
 
 .PHONY: docs-deploy
 docs-deploy:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## ✨ Features
 
-- 🔥 **Elegant, Pythonic API** - Feels natural to Python developers
+- 🔥 **Elegant, Pythonic API** - Feels natural to Python developers including fluent and context manager style resource builders
 - ⚡ **Async First** - Native async/await support for high performance
 - 🛡️ **Type Safe** - Full mypy support and runtime validation
 - 🧪 **Testing Ready** - Built-in pytest fixtures for K8s integration tests
@@ -72,6 +72,246 @@ for pod in k8s.core.v1.Pod.list(namespace="default"):
 async for pod in await k8s.core.v1.Pod.async_list():
     print(f"Found pod: {pod.metadata.name}")
 ```
+### Building resources
+
+#### Using Models
+
+```python
+from cloudcoil import apimachinery
+import cloudcoil.models.kubernetes.core.v1 as k8score
+import cloudcoil.models.kubernetes.apps.v1 as k8sapps
+
+# Create a Deployment
+deployment = k8sapps.Deployment(
+    metadata=apimachinery.ObjectMeta(name="nginx"),
+    spec=k8sapps.DeploymentSpec(
+        replicas=3,
+        selector=apimachinery.LabelSelector(
+            match_labels={"app": "nginx"}
+        ),
+        template=k8score.PodTemplateSpec(
+            metadata=apimachinery.ObjectMeta(
+                labels={"app": "nginx"}
+            ),
+            spec=k8score.PodSpec(
+                containers=[
+                    k8score.Container(
+                        name="nginx",
+                        image="nginx:latest",
+                        ports=[k8score.ContainerPort(container_port=80)]
+                    )
+                ]
+            )
+        )
+    )
+).create()
+
+# Create a Service
+service = k8score.Service(
+    metadata=apimachinery.ObjectMeta(name="nginx"),
+    spec=k8score.ServiceSpec(
+        selector={"app": "nginx"},
+        ports=[k8score.ServicePort(port=80, target_port=80)]
+    )
+).create()
+
+# List Deployments
+for deploy in k8sapps.Deployment.list():
+    print(f"Found deployment: {deploy.metadata.name}")
+
+# Update a Deployment
+deployment.spec.replicas = 5
+deployment.save()
+
+# Delete resources
+k8score.Service.delete("nginx")
+k8sapps.Deployment.delete("nginx")
+```
+
+#### Using the Fluent Builder API
+
+Cloudcoil provides a powerful fluent builder API for Kubernetes resources with full IDE support and rich autocomplete capabilities:
+
+```python
+from cloudcoil.models.kubernetes.apps.v1 import Deployment
+from cloudcoil.models.kubernetes.core.v1 import Service
+
+# Create a Deployment using the fluent builder
+# The fluent style is great for one-liners and simple configurations
+nginx_deployment = (
+    Deployment.builder()
+    # Metadata can be configured in a single chain for simple objects
+    .metadata(lambda metadata: metadata
+        .name("nginx")
+        .namespace("default")
+    )
+    # Complex nested structures can be built using nested lambda functions
+    .spec(lambda deployment_spec: deployment_spec
+        .replicas(3)
+        # Each level of nesting gets its own lambda for clarity
+        .selector(lambda label_selector: label_selector
+            .match_labels({"app": "nginx"})
+        )
+        .template(lambda pod_template: pod_template
+            .metadata(lambda pod_metadata: pod_metadata
+                .labels({"app": "nginx"})
+            )
+            .spec(lambda pod_spec: pod_spec
+                # Lists can be built using array literals with lambda items
+                .containers([
+                    lambda container: container
+                    .name("nginx")
+                    .image("nginx:latest")
+                    # Nested collections can use the add() helper
+                    .ports(lambda port_list: port_list.add(
+                        lambda port: port.container_port(80)
+                    ))
+                ])
+            )
+        )
+    )
+    .build()
+)
+
+# Create a Service using the builder
+service = (
+    Service.builder()
+    .metadata(lambda m: m
+        .name("nginx")
+        .namespace("default")
+    )
+    .spec(lambda s: s
+        .selector({"app": "nginx"})
+        .ports(lambda ports: ports.add(lambda p: p.container_port(80)))
+    )
+    .build()
+)
+```
+
+The fluent builder provides:
+- ✨ Full IDE support with detailed type information
+- 🔍 Rich autocomplete for all fields and nested objects
+- ⚡ Compile-time validation of your configuration
+- 🎯 Clear and chainable API that guides you through resource creation
+
+#### Using the Context Manager Builder API
+
+For complex nested resources, Cloudcoil also provides a context manager-based builder pattern that can make the structure more clear:
+
+```python
+from cloudcoil.models.kubernetes.apps.v1 import Deployment
+from cloudcoil.models.kubernetes.core.v1 import Service
+
+# Create a deployment using context managers
+# Context managers are ideal for deeply nested structures
+with Deployment.new() as nginx_deployment:
+    # Each context creates a clear visual scope
+    with nginx_deployment.metadata() as deployment_metadata:
+        deployment_metadata.name("nginx")
+        deployment_metadata.namespace("default")
+    
+    with nginx_deployment.spec() as deployment_spec:
+        # Simple fields can be set directly
+        deployment_spec.replicas(3)
+        
+        # Each nested object gets its own context
+        with deployment_spec.selector() as label_selector:
+            label_selector.match_labels({"app": "nginx"})
+        
+        with deployment_spec.template() as pod_template:
+            with pod_template.metadata() as pod_metadata:
+                pod_metadata.labels({"app": "nginx"})
+            
+            with pod_template.spec() as pod_spec:
+                # Collections use a parent context for the list
+                with pod_spec.containers() as container_list:
+                    # And child contexts for each item
+                    with container_list.add() as nginx_container:
+                        nginx_container.name("nginx")
+                        nginx_container.image("nginx:latest")
+                        # Ports can be added one by one
+                        with nginx_container.add_port() as container_port:
+                            container_port.container_port(80)
+
+final_deployment = nginx_deployment.build()
+
+# Create a service using context managers
+with Service.new() as nginx_service:
+    # Context managers make the structure very clear
+    with nginx_service.metadata() as service_metadata:
+        service_metadata.name("nginx")
+        service_metadata.namespace("default")
+    
+    with nginx_service.spec() as service_spec:
+        # Simple fields can still be set directly
+        service_spec.selector({"app": "nginx"})
+        # Port configuration is more readable with contexts
+        with service_spec.add_port() as service_port:
+            service_port.port(80)
+            service_port.target_port(80)
+
+final_service = nginx_service.build()
+```
+
+The context manager builder provides:
+- 🎭 Clear visual nesting of resource structure
+- 🔒 Automatic resource cleanup
+- 🎯 Familiar Python context manager pattern
+- ✨ Same great IDE support as the fluent builder
+
+#### Mixing Builder Styles
+
+CloudCoil's intelligent builder system automatically detects which style you're using and provides appropriate IDE support:
+
+```python
+from cloudcoil.models.kubernetes.apps.v1 import Deployment
+from cloudcoil import apimachinery
+
+# Mixing styles lets you choose the best approach for each part
+# The IDE automatically adapts to your chosen style at each level
+with Deployment.new() as nginx_deployment:
+    # Direct object initialization with full type checking
+    nginx_deployment.metadata(apimachinery.ObjectMeta(
+        name="nginx",
+        namespace="default",
+        labels={"app": "nginx"}
+    ))
+    
+    with nginx_deployment.spec() as deployment_spec:
+        # IDE shows all available fields with types
+        deployment_spec.replicas(3)
+        # Fluent style with rich autocomplete
+        deployment_spec.selector(lambda sel: sel.match_labels({"app": "nginx"}))
+        
+        # Context manager style with full type hints
+        with deployment_spec.template() as pod_template:
+            # Mix and match freely - IDE adjusts automatically
+            pod_template.metadata(apimachinery.ObjectMeta(labels={"app": "nginx"}))
+            with pod_template.spec() as pod_spec:
+                with pod_spec.containers() as container_list:
+                    with container_list.add() as nginx_container:
+                        # Complete IDE support regardless of style
+                        nginx_container.name("nginx")
+                        nginx_container.image("nginx:latest")
+                        # Switch styles any time
+                        nginx_container.ports(lambda ports: ports
+                            .add(lambda p: p.container_port(80))
+                            .add(lambda p: p.container_port(443))
+                        )
+
+final_deployment = nginx_deployment.build()
+```
+
+This flexibility allows you to:
+- 🔀 Choose the most appropriate style for each part of your configuration
+- 📖 Maximize readability for both simple and complex structures
+- 🎨 Format your code according to your team's preferences
+- 🧠 Get full IDE support with automatic style detection
+- ✨ Enjoy rich autocomplete in all styles
+- ⚡ Benefit from type checking across mixed styles
+- 🎯 Receive immediate feedback on type errors
+- 🔍 See documentation for all fields regardless of style
+
 
 ### Creating Resources
 
@@ -346,7 +586,7 @@ Cloudcoil supports generating typed models from CustomResourceDefinitions (CRDs)
 
 ### Using the Cookiecutter Template
 
-The fastest way to get started is using our cookiecutter template: [cloudcoil-models-cookiecutter](https://github.com/cloudcoil/cloudcoil-models-cookiecutter)
+The fastest way to get started is using our cookiecutter template: [cloudcoil-models-cookiecutter](https://github.com/cloudcoil/cloudcoil/tree/main/cookiecutter)
 
 ### Codegen Config
 

--- a/cloudcoil/apimachinery.py
+++ b/cloudcoil/apimachinery.py
@@ -37,7 +37,7 @@ class Quantity(RootModel[str]):
 
         def root(self, value: str, /) -> Self:
             """
-                    Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+            Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
 
             The serialization format is:
 
@@ -80,7 +80,7 @@ class Quantity(RootModel[str]):
 
         def __call__(self, value: str, /) -> Self:
             """
-                    Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+            Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
 
             The serialization format is:
 
@@ -1038,7 +1038,7 @@ class StatusCause(BaseModel):
 
         def field(self, value: Optional[str], /) -> Self:
             """
-                    The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+            The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
 
             Examples:
               "name" - the field "name" on the current resource
@@ -2383,7 +2383,7 @@ class ObjectMeta(BaseModel):
 
         def creation_timestamp(self, value_or_callback=None, /):
             """
-                    CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+            CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
 
             Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
             """
@@ -2423,7 +2423,7 @@ class ObjectMeta(BaseModel):
 
         def deletion_timestamp(self, value_or_callback=None, /):
             """
-                    DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+            DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
 
             Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
             """
@@ -2450,7 +2450,7 @@ class ObjectMeta(BaseModel):
 
         def generate_name(self, value: Optional[str], /) -> Self:
             """
-                    GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+            GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
 
             If this field is specified and the generated name exists, the server will return a 409.
 
@@ -2518,7 +2518,7 @@ class ObjectMeta(BaseModel):
 
         def namespace(self, value: Optional[str], /) -> Self:
             """
-                    Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+            Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
 
             Must be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces
             """
@@ -2565,7 +2565,7 @@ class ObjectMeta(BaseModel):
 
         def resource_version(self, value: Optional[str], /) -> Self:
             """
-                    An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+            An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
 
             Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
             """
@@ -2579,7 +2579,7 @@ class ObjectMeta(BaseModel):
 
         def uid(self, value: Optional[str], /) -> Self:
             """
-                    UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+            UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
 
             Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
             """
@@ -2890,11 +2890,11 @@ class WatchEvent(BaseModel):
 
         def object(self, value_or_callback=None, /):
             """
-                   Object is:
-            * If Type is Added or Modified: the new state of the object.
-            * If Type is Deleted: the state of the object immediately before deletion.
-            * If Type is Error: *Status is recommended; other types may make sense
-              depending on context.
+            Object is:
+             * If Type is Added or Modified: the new state of the object.
+             * If Type is Deleted: the state of the object immediately before deletion.
+             * If Type is Error: *Status is recommended; other types may make sense
+               depending on context.
             """
             if self._in_context and value_or_callback is None:
                 context = RawExtension.BuilderContext()

--- a/cloudcoil/codegen/templates/pydantic_v2/BaseModel.jinja2
+++ b/cloudcoil/codegen/templates/pydantic_v2/BaseModel.jinja2
@@ -11,7 +11,7 @@ class {{ class_name }}(BaseModel):{% if comment is defined %}  # {{ comment }}{%
 {%- endif %}
 {%- if description %}
     """
-    {{ description | indent(4) }}
+    {{ description | replace("\t", " "*4) | trim | indent(4) }}
     """
 {%- endif %}
 
@@ -41,7 +41,7 @@ class {{ class_name }}(BaseModel):{% if comment is defined %}  # {{ comment }}{%
         def {{ field_setter_name }}(self, value_or_callback=None, /):
             {%- if field.docstring %}
             """
-            {{ field.docstring | indent(4) }}
+            {{ field.docstring | replace("\t", " "*4) | trim | indent(12) }}
             """
             {%- endif %}
             if self._in_context and value_or_callback is None:
@@ -62,7 +62,7 @@ class {{ class_name }}(BaseModel):{% if comment is defined %}  # {{ comment }}{%
         def {{ field_setter_name }}(self, value: {{ field.type_hint }}, /) -> Self:
             {%- if field.docstring %}
             """
-            {{ field.docstring | indent(4) }}
+            {{ field.docstring | replace("\t", " "*4) | trim | indent(12) }}
             """
             {%- endif %}
             return self._set("{{ field.name }}", value)
@@ -81,7 +81,7 @@ class {{ class_name }}(BaseModel):{% if comment is defined %}  # {{ comment }}{%
         def {{ field_setter_name }}(self, value_or_callback=None, /):
             {%- if field.docstring %}
             """
-            {{ field.docstring | indent(4) }}
+            {{ field.docstring | replace("\t", " "*4) | trim | indent(12) }}
             """
             {%- endif %}
             if self._in_context and value_or_callback is None:
@@ -102,7 +102,7 @@ class {{ class_name }}(BaseModel):{% if comment is defined %}  # {{ comment }}{%
         def {{ field_setter_name }}(self, value: {{ field.type_hint }}, /) -> Self:
             {%- if field.docstring %}
             """
-            {{ field.docstring | indent(4) }}
+            {{ field.docstring | replace("\t", " "*4) | trim | indent(12) }}
             """
             {%- endif %}
             return self._set("{{ field.name }}", value)
@@ -157,7 +157,7 @@ class {{ class_name }}(BaseModel):{% if comment is defined %}  # {{ comment }}{%
     {%- endif %}
     {%- if field.docstring %}
     """
-    {{ field.docstring | indent(4) }}
+    {{ field.docstring | replace("\t", " "*4) | trim | indent(4) }}
     """
     {%- endif %}
 {%- for method in methods -%}

--- a/cloudcoil/codegen/templates/pydantic_v2/RootModel.jinja2
+++ b/cloudcoil/codegen/templates/pydantic_v2/RootModel.jinja2
@@ -11,7 +11,7 @@
 class {{ class_name }}({{ base_class }}{%- if fields -%}[{{get_type_hint(fields)}}]{%- endif -%}):{% if comment is defined %}  # {{ comment }}{% endif %}
 {%- if description %}
     """
-    {{ description | indent(4) }}
+    {{ description | replace("\t", " "*4) | trim | indent(4) }}
     """
 {%- endif %}
 
@@ -35,7 +35,7 @@ class {{ class_name }}({{ base_class }}{%- if fields -%}[{{get_type_hint(fields)
         def root(self, value: {{ field.type_hint }}, /) -> Self:
             {%- if field.docstring %}
             """
-            {{ field.docstring | indent(4) }}
+            {{ field.docstring | replace("\t", " "*4) | trim | indent(12) }}
             """
             {%- endif %}
             self._value = value
@@ -44,7 +44,7 @@ class {{ class_name }}({{ base_class }}{%- if fields -%}[{{get_type_hint(fields)
         def __call__(self, value: {{ field.type_hint }}, /) -> Self:
             {%- if field.docstring %}
             """
-            {{ field.docstring | indent(4) }}
+            {{ field.docstring | replace("\t", " "*4) | trim | indent(12) }}
             """
             {%- endif %}
             self._value = value
@@ -68,7 +68,7 @@ class {{ class_name }}({{ base_class }}{%- if fields -%}[{{get_type_hint(fields)
     {%- endif %}
     {%- if field.docstring %}
     """
-    {{ field.docstring | indent(4) }}
+    {{ field.docstring | replace("\t", " "*4) | trim | indent(4) }}
     """
     {%- endif %}
 {%- endif %}

--- a/cookiecutter/cookiecutter.json
+++ b/cookiecutter/cookiecutter.json
@@ -1,5 +1,6 @@
 {
     "model_name": "model",
+    "module_name": "{{ cookiecutter.model_name | replace('-', '_') }}",
     "author_name": "Sambhav Kothari",
     "author_email": "sambhavs.email@gmail.com",
     "crd_namespace": "default",

--- a/cookiecutter/models-{{ cookiecutter.model_name }}/Makefile
+++ b/cookiecutter/models-{{ cookiecutter.model_name }}/Makefile
@@ -6,7 +6,7 @@ test:
 lint:
 	uv run ruff check cloudcoil tests
 	uv run ruff format --check cloudcoil tests
-	uv run mypy -p cloudcoil.models.{{cookiecutter.model_name}} 
+	uv run mypy -p cloudcoil.models.{{cookiecutter.module_name}} 
 
 .PHONY: fix-lint
 fix-lint:

--- a/cookiecutter/models-{{ cookiecutter.model_name }}/pyproject.toml
+++ b/cookiecutter/models-{{ cookiecutter.model_name }}/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "cloudcoil.models.{{ cookiecutter.model_name }}"
+name = "cloudcoil.models.{{ cookiecutter.module_name }}"
 version = "0.0.0"
 description = "Versioned {{cookiecutter.model_name}} models for cloudcoil"
 authors = [{ name = "{{cookiecutter.author_name}}", email = "{{cookiecutter.author_email}}" }]
@@ -80,7 +80,7 @@ only-include = ["cloudcoil"]
 [[tool.cloudcoil.codegen.models]]
 # Unique name for the models
 # This will be used as the name for the setuptools entrypoints
-namespace = "cloudcoil.models.{{cookiecutter.model_name}}"
+namespace = "cloudcoil.models.{{cookiecutter.module_name}}"
 input = "{{ cookiecutter.crd_url }}"
 {%- if cookiecutter.crd_namespace %}
 crd-namespace = "{{ cookiecutter.crd_namespace }}"

--- a/cookiecutter/models-{{ cookiecutter.model_name }}/tests/test_import.py
+++ b/cookiecutter/models-{{ cookiecutter.model_name }}/tests/test_import.py
@@ -1,8 +1,8 @@
 import pytest
-import cloudcoil.models.{{cookiecutter.model_name}} as {{cookiecutter.model_name}}
+import cloudcoil.models.{{cookiecutter.module_name}} as {{cookiecutter.module_name}}
 from types import ModuleType
 
 
 def test_has_modules():
-    modules = list(filter(lambda x: isinstance(x, ModuleType), {{cookiecutter.model_name}}.__dict__.values()))
-    assert modules, "No modules found in {{cookiecutter.model_name}}"
+    modules = list(filter(lambda x: isinstance(x, ModuleType), {{cookiecutter.module_name}}.__dict__.values()))
+    assert modules, "No modules found in {{cookiecutter.module_name}}"

--- a/models/cert-manager/README.md
+++ b/models/cert-manager/README.md
@@ -1,0 +1,204 @@
+## 🔧 Installation
+
+Using [uv](https://github.com/astral-sh/uv) (recommended):
+
+```bash
+# Install with cert-manager support
+uv add cloudcoil.models.cert_manager
+```
+
+Using pip:
+
+```bash
+pip install cloudcoil.models.cert_manager
+```
+
+## 💡 Examples
+
+### Using cert-manager Models
+
+```python
+from cloudcoil import apimachinery
+import cloudcoil.models.cert_manager.v1 as cm
+
+# Create a Certificate
+certificate = cm.Certificate(
+    metadata=apimachinery.ObjectMeta(name="example-cert", namespace="default"),
+    spec=cm.CertificateSpec(
+        secret_name="example-cert-tls",
+        issuer_ref=cm.IssuerRef(name="example-issuer"),
+        dns_names=["example.com"]
+    )
+).create()
+
+# List Certificates
+for cert in cm.Certificate.list(namespace="default"):
+    print(f"Found certificate: {cert.metadata.name}")
+
+# Update a Certificate
+certificate.spec.dns_names.append("www.example.com")
+certificate.save()
+
+# Delete a Certificate
+cm.Certificate.delete("example-cert", namespace="default")
+```
+
+### Using the Fluent Builder API
+
+Cloudcoil provides a powerful fluent builder API for cert-manager resources with full IDE support and rich autocomplete capabilities:
+
+```python
+from cloudcoil.models.cert_manager.v1 import Certificate, ClusterIssuer
+
+# Create a Certificate using the fluent builder
+# The fluent style is great for one-liners and simple configurations
+certificate = (
+    Certificate.builder()
+    .metadata(lambda metadata: metadata
+        .name("example-cert")
+        .namespace("default")
+        .labels({"env": "prod"})
+    )
+    .spec(lambda cert_spec: cert_spec
+        .secret_name("example-cert-tls")
+        .issuer_ref(lambda issuer: issuer
+            .name("example-issuer")
+            .kind("ClusterIssuer")
+        )
+        .dns_names(["example.com", "www.example.com"])
+        .subject(lambda subject: subject
+            .organizations(["Example Corp"])
+        )
+    )
+    .build()
+)
+
+# Create a ClusterIssuer using the builder
+cluster_issuer = (
+    ClusterIssuer.builder()
+    .metadata(lambda m: m.name("letsencrypt-prod"))
+    .spec(
+        lambda s: s.acme(
+            lambda acme: acme.email("admin@example.com")
+            .server("https://acme-v02.api.letsencrypt.org/directory")
+            .private_key_secret_ref(lambda ref: ref.name("letsencrypt-account-key"))
+            .solvers(
+                lambda solvers: solvers.add(
+                    lambda solver: solver.http01(
+                        lambda http: http.ingress(lambda ing: ing.class_("nginx"))
+                    )
+                )
+            )
+        )
+    )
+    .build()
+)
+```
+
+### Using the Context Manager Builder API
+
+For complex nested resources, Cloudcoil also provides a context manager-based builder pattern that can make the structure more clear:
+
+```python
+from cloudcoil.models.cert_manager.v1 import Certificate, ClusterIssuer
+
+# Create a certificate using context managers
+with Certificate.new() as cert:
+    with cert.metadata() as metadata:
+        metadata.name("example-cert")
+        metadata.namespace("default")
+        metadata.labels({"env": "prod"})
+    
+    with cert.spec() as spec:
+        spec.secret_name("example-cert-tls")
+        
+        with spec.issuer_ref() as issuer_ref:
+            issuer_ref.name("example-issuer")
+            issuer_ref.kind("ClusterIssuer")
+        
+        spec.dns_names(["example.com", "www.example.com"])
+        
+        with spec.subject() as subject:
+            subject.organizations(["Example Corp"])
+
+final_cert = cert.build()
+
+# Create a ClusterIssuer using context managers
+with ClusterIssuer.new() as issuer:
+    with issuer.metadata() as metadata:
+        metadata.name("letsencrypt-prod")
+    
+    with issuer.spec() as spec:
+        with spec.acme() as acme:
+            acme.email("admin@example.com")
+            acme.server("https://acme-v02.api.letsencrypt.org/directory")
+            
+            with acme.private_key_secret_ref() as key_ref:
+                key_ref.name("letsencrypt-account-key")
+            
+            with acme.solvers() as solvers:
+                with solvers.add() as solver:
+                    with solver.http01() as http:
+                        with http.ingress() as ingress:
+                            ingress.class_("nginx")
+
+final_issuer = issuer.build()
+```
+
+The context manager builder provides:
+- 🎭 Clear visual nesting of resource structure
+- 🔒 Automatic resource cleanup
+- 🎯 Familiar Python context manager pattern
+- ✨ Same great IDE support as the fluent builder
+
+### Mixing Builder Styles
+
+CloudCoil's intelligent builder system automatically detects which style you're using and provides appropriate IDE support:
+
+```python
+from cloudcoil.models.cert_manager.v1 import Certificate
+from cloudcoil import apimachinery
+
+# Mixing styles lets you choose the best approach for each part
+with Certificate.new() as cert:
+    # Direct object initialization with full type checking
+    cert.metadata(apimachinery.ObjectMeta(
+        name="example-cert",
+        namespace="default",
+        labels={"env": "prod"}
+    ))
+    
+    with cert.spec() as spec:
+        # Simple fields directly
+        spec.secret_name("example-cert-tls")
+        # Fluent style
+        spec.issuer_ref(lambda ref: ref
+            .name("example-issuer")
+            .kind("ClusterIssuer")
+        )
+        # Direct assignment
+        spec.dns_names(["example.com", "www.example.com"])
+        # Context manager style
+        with spec.subject() as subject:
+            subject.organizations(["Example Corp"])
+
+final_cert = cert.build()
+```
+
+This flexibility allows you to:
+- 🔀 Choose the most appropriate style for each part of your configuration
+- 📖 Maximize readability for both simple and complex structures
+- 🎨 Format your code according to your team's preferences
+- 🧠 Get full IDE support with automatic style detection
+- ✨ Enjoy rich autocomplete in all styles
+- ⚡ Benefit from type checking across mixed styles
+- 🎯 Receive immediate feedback on type errors
+- 🔍 See documentation for all fields regardless of style
+
+## 📚 Documentation
+
+For complete documentation, visit [cloudcoil.github.io/cloudcoil](https://cloudcoil.github.io/cloudcoil)
+
+## 📜 License
+
+Apache License, Version 2.0 - see [LICENSE](LICENSE)

--- a/models/cert-manager/cookiecutter.yaml
+++ b/models/cert-manager/cookiecutter.yaml
@@ -1,0 +1,8 @@
+default_context:
+  model_name: cert-manager
+  author_name: Sambhav Kothari
+  author_email: sambhavs.email@gmail.com
+  crd_namespace: io.cert-manager
+  crd_url: https://github.com/cert-manager/cert-manager/releases/download/v1.16.3/cert-manager.crds.yaml
+  versions: "'1.16.3'"
+  version_replacement_sed: releases/download

--- a/models/cert-manager/pyproject.toml
+++ b/models/cert-manager/pyproject.toml
@@ -1,0 +1,3 @@
+additional-datamodel-codegen-args = [
+    "--collapse-root-models",
+]

--- a/models/fluxcd/README.md
+++ b/models/fluxcd/README.md
@@ -108,6 +108,96 @@ The fluent builder provides:
 - ⚡ Compile-time validation of your configuration
 - 🎯 Clear and chainable API that guides you through resource creation
 
+### Using the Context Manager Builder API
+
+For complex nested resources, Cloudcoil also provides a context manager-based builder pattern that can make the structure more clear:
+
+```python
+from cloudcoil.models.fluxcd.source.v1 import GitRepository
+from cloudcoil.models.fluxcd.kustomize.v1 import Kustomization
+
+# Create a GitRepository using context managers
+with GitRepository.new() as repo:
+    with repo.metadata() as metadata:
+        metadata.name("my-app")
+        metadata.namespace("default")
+        metadata.labels({"env": "prod"})
+    
+    with repo.spec() as spec:
+        spec.url("https://github.com/org/repo")
+        spec.interval("1m")
+        
+        with spec.ref() as ref:
+            ref.branch("main")
+
+final_repo = repo.build()
+
+# Create a Kustomization using context managers
+with Kustomization.new() as kustomization:
+    with kustomization.metadata() as metadata:
+        metadata.name("my-app")
+        metadata.namespace("default")
+    
+    with kustomization.spec() as spec:
+        spec.path("./kustomize")
+        spec.interval("5m")
+        spec.prune(True)
+        
+        with spec.source_ref() as ref:
+            ref.kind("GitRepository")
+            ref.name("my-app")
+
+final_kustomization = kustomization.build()
+```
+
+The context manager builder provides:
+- 🎭 Clear visual nesting of resource structure
+- 🔒 Automatic resource cleanup
+- 🎯 Familiar Python context manager pattern
+- ✨ Same great IDE support as the fluent builder
+
+### Mixing Builder Styles
+
+CloudCoil's intelligent builder system automatically detects which style you're using and provides appropriate IDE support:
+
+```python
+from cloudcoil.models.fluxcd.source.v1 import GitRepository
+from cloudcoil import apimachinery
+
+# Mixing styles lets you choose the best approach for each part
+with GitRepository.new() as repo:
+    # Direct object initialization with full type checking
+    repo.metadata(apimachinery.ObjectMeta(
+        name="my-app",
+        namespace="default",
+        labels={"env": "prod"}
+    ))
+    
+    with repo.spec() as spec:
+        # Simple fields directly
+        spec.url("https://github.com/org/repo")
+        spec.interval("1m")
+        # Fluent style
+        spec.ref(lambda r: r
+            .branch("main")
+            .tag("v1.0.0")
+        )
+        # Direct assignment
+        spec.timeout = "1m"
+
+final_repo = repo.build()
+```
+
+This flexibility allows you to:
+- 🔀 Choose the most appropriate style for each part of your configuration
+- 📖 Maximize readability for both simple and complex structures
+- 🎨 Format your code according to your team's preferences
+- 🧠 Get full IDE support with automatic style detection
+- ✨ Enjoy rich autocomplete in all styles
+- ⚡ Benefit from type checking across mixed styles
+- 🎯 Receive immediate feedback on type errors
+- 🔍 See documentation for all fields regardless of style
+
 ## 📚 Documentation
 
 For complete documentation, visit [cloudcoil.github.io/cloudcoil](https://cloudcoil.github.io/cloudcoil)

--- a/models/kubernetes/README.md
+++ b/models/kubernetes/README.md
@@ -77,28 +77,36 @@ Cloudcoil provides a powerful fluent builder API for Kubernetes resources with f
 from cloudcoil.models.kubernetes.apps.v1 import Deployment
 from cloudcoil.models.kubernetes.core.v1 import Service
 
-# Create a Deployment using the builder
-deployment = (
+# Create a Deployment using the fluent builder
+# The fluent style is great for one-liners and simple configurations
+nginx_deployment = (
     Deployment.builder()
-    .metadata(lambda m: m
+    # Metadata can be configured in a single chain for simple objects
+    .metadata(lambda metadata: metadata
         .name("nginx")
         .namespace("default")
     )
-    .spec(lambda s: s
+    # Complex nested structures can be built using nested lambda functions
+    .spec(lambda deployment_spec: deployment_spec
         .replicas(3)
-        .selector(lambda sel: sel
+        # Each level of nesting gets its own lambda for clarity
+        .selector(lambda label_selector: label_selector
             .match_labels({"app": "nginx"})
         )
-        .template(lambda t: t
-            .metadata(lambda m: m
+        .template(lambda pod_template: pod_template
+            .metadata(lambda pod_metadata: pod_metadata
                 .labels({"app": "nginx"})
             )
-            .spec(lambda ps: ps
+            .spec(lambda pod_spec: pod_spec
+                # Lists can be built using array literals with lambda items
                 .containers([
-                    lambda c: c
+                    lambda container: container
                     .name("nginx")
                     .image("nginx:latest")
-                    .ports(lambda ports: ports.add(lambda p: p.container_port(80)))
+                    # Nested collections can use the add() helper
+                    .ports(lambda port_list: port_list.add(
+                        lambda port: port.container_port(80)
+                    ))
                 ])
             )
         )
@@ -126,6 +134,124 @@ The fluent builder provides:
 - 🔍 Rich autocomplete for all fields and nested objects
 - ⚡ Compile-time validation of your configuration
 - 🎯 Clear and chainable API that guides you through resource creation
+
+### Using the Context Manager Builder API
+
+For complex nested resources, Cloudcoil also provides a context manager-based builder pattern that can make the structure more clear:
+
+```python
+from cloudcoil.models.kubernetes.apps.v1 import Deployment
+from cloudcoil.models.kubernetes.core.v1 import Service
+
+# Create a deployment using context managers
+# Context managers are ideal for deeply nested structures
+with Deployment.new() as nginx_deployment:
+    # Each context creates a clear visual scope
+    with nginx_deployment.metadata() as deployment_metadata:
+        deployment_metadata.name("nginx")
+        deployment_metadata.namespace("default")
+    
+    with nginx_deployment.spec() as deployment_spec:
+        # Simple fields can be set directly
+        deployment_spec.replicas(3)
+        
+        # Each nested object gets its own context
+        with deployment_spec.selector() as label_selector:
+            label_selector.match_labels({"app": "nginx"})
+        
+        with deployment_spec.template() as pod_template:
+            with pod_template.metadata() as pod_metadata:
+                pod_metadata.labels({"app": "nginx"})
+            
+            with pod_template.spec() as pod_spec:
+                # Collections use a parent context for the list
+                with pod_spec.containers() as container_list:
+                    # And child contexts for each item
+                    with container_list.add() as nginx_container:
+                        nginx_container.name("nginx")
+                        nginx_container.image("nginx:latest")
+                        # Ports can be added one by one
+                        with nginx_container.add_port() as container_port:
+                            container_port.container_port(80)
+
+final_deployment = nginx_deployment.build()
+
+# Create a service using context managers
+with Service.new() as nginx_service:
+    # Context managers make the structure very clear
+    with nginx_service.metadata() as service_metadata:
+        service_metadata.name("nginx")
+        service_metadata.namespace("default")
+    
+    with nginx_service.spec() as service_spec:
+        # Simple fields can still be set directly
+        service_spec.selector({"app": "nginx"})
+        # Port configuration is more readable with contexts
+        with service_spec.add_port() as service_port:
+            service_port.port(80)
+            service_port.target_port(80)
+
+final_service = nginx_service.build()
+```
+
+The context manager builder provides:
+- 🎭 Clear visual nesting of resource structure
+- 🔒 Automatic resource cleanup
+- 🎯 Familiar Python context manager pattern
+- ✨ Same great IDE support as the fluent builder
+
+### Mixing Builder Styles
+
+CloudCoil's intelligent builder system automatically detects which style you're using and provides appropriate IDE support:
+
+```python
+from cloudcoil.models.kubernetes.apps.v1 import Deployment
+from cloudcoil import apimachinery
+
+# Mixing styles lets you choose the best approach for each part
+# The IDE automatically adapts to your chosen style at each level
+with Deployment.new() as nginx_deployment:
+    # Direct object initialization with full type checking
+    nginx_deployment.metadata(apimachinery.ObjectMeta(
+        name="nginx",
+        namespace="default",
+        labels={"app": "nginx"}
+    ))
+    
+    with nginx_deployment.spec() as deployment_spec:
+        # IDE shows all available fields with types
+        deployment_spec.replicas(3)
+        # Fluent style with rich autocomplete
+        deployment_spec.selector(lambda sel: sel.match_labels({"app": "nginx"}))
+        
+        # Context manager style with full type hints
+        with deployment_spec.template() as pod_template:
+            # Mix and match freely - IDE adjusts automatically
+            pod_template.metadata(apimachinery.ObjectMeta(labels={"app": "nginx"}))
+            with pod_template.spec() as pod_spec:
+                with pod_spec.containers() as container_list:
+                    with container_list.add() as nginx_container:
+                        # Complete IDE support regardless of style
+                        nginx_container.name("nginx")
+                        nginx_container.image("nginx:latest")
+                        # Switch styles any time
+                        nginx_container.ports(lambda ports: ports
+                            .add(lambda p: p.container_port(80))
+                            .add(lambda p: p.container_port(443))
+                        )
+
+final_deployment = nginx_deployment.build()
+```
+
+This flexibility allows you to:
+- 🔀 Choose the most appropriate style for each part of your configuration
+- 📖 Maximize readability for both simple and complex structures
+- 🎨 Format your code according to your team's preferences
+- 🧠 Get full IDE support with automatic style detection
+- ✨ Enjoy rich autocomplete in all styles
+- ⚡ Benefit from type checking across mixed styles
+- 🎯 Receive immediate feedback on type errors
+- 🔍 See documentation for all fields regardless of style
 
 ## 📚 Documentation
 

--- a/models/kyverno/README.md
+++ b/models/kyverno/README.md
@@ -1,0 +1,206 @@
+## 🔧 Installation
+
+Using [uv](https://github.com/astral-sh/uv) (recommended):
+
+```bash
+# Install with Kyverno support
+uv add cloudcoil.models.kyverno
+```
+
+Using pip:
+
+```bash
+pip install cloudcoil.models.kyverno
+```
+
+## 💡 Examples
+
+### Using Kyverno Models
+
+```python
+from cloudcoil import apimachinery
+import cloudcoil.models.kyverno.v1 as kyverno
+
+# Create a ClusterPolicy
+policy = kyverno.ClusterPolicy(
+    metadata=apimachinery.ObjectMeta(name="require-labels"),
+    spec=kyverno.ClusterPolicySpec(
+        rules=[
+            kyverno.Rule(
+                name="require-team-label",
+                match=kyverno.Match(
+                    resources=kyverno.Resources(
+                        kinds=["Deployment", "StatefulSet"]
+                    )
+                ),
+                validate=kyverno.Validate(
+                    message="The label 'team' is required",
+                    pattern={
+                        "metadata": {
+                            "labels": {
+                                "team": "*"
+                            }
+                        }
+                    }
+                )
+            )
+        ]
+    )
+).create()
+
+# List Policies
+for pol in kyverno.ClusterPolicy.list():
+    print(f"Found policy: {pol.metadata.name}")
+
+# Update a Policy
+policy.spec.rules[0].validate.message = "The 'team' label is mandatory"
+policy.save()
+
+# Delete a Policy
+kyverno.ClusterPolicy.delete("require-labels")
+```
+
+### Using the Fluent Builder API
+
+Cloudcoil provides a powerful fluent builder API for Kyverno resources with full IDE support and rich autocomplete capabilities:
+
+```python
+from cloudcoil.models.kyverno.v1 import ClusterPolicy
+
+# Create a ClusterPolicy using the builder
+policy = (
+    ClusterPolicy.builder()
+    .metadata(lambda m: m
+        .name("require-labels")
+    )
+    .spec(lambda s: s
+        .rules([
+            lambda r: r
+            .name("require-team-label")
+            .match(lambda m: m
+                .resources(lambda res: res
+                    .kinds(["Deployment", "StatefulSet"])
+                )
+            )
+            .validate(lambda v: v
+                .message("The label 'team' is required")
+                .pattern({
+                    "metadata": {
+                        "labels": {
+                            "team": "*"
+                        }
+                    }
+                })
+            )
+        ])
+    )
+    .build()
+)
+```
+
+The fluent builder provides:
+- ✨ Full IDE support with detailed type information
+- 🔍 Rich autocomplete for all fields and nested objects
+- ⚡ Compile-time validation of your configuration
+- 🎯 Clear and chainable API that guides you through resource creation
+
+### Using the Context Manager Builder API
+
+For complex nested resources, Cloudcoil also provides a context manager-based builder pattern that can make the structure more clear:
+
+```python
+from cloudcoil.models.kyverno.v1 import ClusterPolicy
+
+# Create a policy using context managers
+with ClusterPolicy.new() as policy:
+    with policy.metadata() as metadata:
+        metadata.name("require-labels")
+        metadata.labels({"app": "kyverno"})
+    
+    with policy.spec() as spec:
+        with spec.rules() as rules:
+            with rules.add() as rule:
+                rule.name("require-team-label")
+                
+                with rule.match() as match:
+                    with match.resources() as resources:
+                        resources.kinds(["Deployment", "StatefulSet"])
+                
+                with rule.validate() as validate:
+                    validate.message("The label 'team' is required")
+                    validate.pattern({
+                        "metadata": {
+                            "labels": {
+                                "team": "*"
+                            }
+                        }
+                    })
+
+final_policy = policy.build()
+```
+
+The context manager builder provides:
+- 🎭 Clear visual nesting of resource structure
+- 🔒 Automatic resource cleanup
+- 🎯 Familiar Python context manager pattern
+- ✨ Same great IDE support as the fluent builder
+
+### Mixing Builder Styles
+
+CloudCoil's intelligent builder system automatically detects which style you're using and provides appropriate IDE support:
+
+```python
+from cloudcoil.models.kyverno.v1 import ClusterPolicy
+from cloudcoil import apimachinery
+
+# Mixing styles lets you choose the best approach for each part
+with ClusterPolicy.new() as policy:
+    # Direct object initialization with full type checking
+    policy.metadata(apimachinery.ObjectMeta(
+        name="require-labels",
+        labels={"app": "kyverno"}
+    ))
+    
+    with policy.spec() as spec:
+        # Fluent style for rules
+        spec.rules([
+            lambda r: r
+            .name("require-team-label")
+            .match(lambda m: m
+                .resources(lambda res: res
+                    .kinds(["Deployment", "StatefulSet"])
+                )
+            )
+            # Context manager style for validate
+            .validate(lambda v: v
+                .message("The label 'team' is required")
+                .pattern({
+                    "metadata": {
+                        "labels": {
+                            "team": "*"
+                        }
+                    }
+                })
+            )
+        ])
+
+final_policy = policy.build()
+```
+
+This flexibility allows you to:
+- 🔀 Choose the most appropriate style for each part of your configuration
+- 📖 Maximize readability for both simple and complex structures
+- 🎨 Format your code according to your team's preferences
+- 🧠 Get full IDE support with automatic style detection
+- ✨ Enjoy rich autocomplete in all styles
+- ⚡ Benefit from type checking across mixed styles
+- 🎯 Receive immediate feedback on type errors
+- 🔍 See documentation for all fields regardless of style
+
+## 📚 Documentation
+
+For complete documentation, visit [cloudcoil.github.io/cloudcoil](https://cloudcoil.github.io/cloudcoil)
+
+## 📜 License
+
+Apache License, Version 2.0 - see [LICENSE](LICENSE)

--- a/models/kyverno/cookiecutter.yaml
+++ b/models/kyverno/cookiecutter.yaml
@@ -1,0 +1,8 @@
+default_context:
+  model_name: kyverno
+  author_name: Sambhav Kothari
+  author_email: sambhavs.email@gmail.com
+  crd_namespace: io.kyverno
+  crd_url: https://github.com/kyverno/kyverno/releases/download/v1.12.7/install.yaml
+  versions: "'1.12.7'"
+  version_replacement_sed: releases/download

--- a/models/kyverno/pyproject.toml
+++ b/models/kyverno/pyproject.toml
@@ -1,0 +1,4 @@
+updates = [
+    { match = "^.*v2alpha1\\.GlobalContextEntry$", jsonpath = "properties.spec.properties.apiCall.properties.refreshInterval.format", delete = true}
+]
+exclude-unknown = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ dev = [
     "pytest-sugar>=1.0.0",
     "pytest-asyncio>=0.25.0",
     "pytest-xdist>=3.6.1",
+    "cloudcoil-models-kubernetes>=1.29.13.1",
 ]
 
 [tool.mypy]

--- a/uv.lock
+++ b/uv.lock
@@ -193,20 +193,20 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
-    { name = "cloudcoil-models-kubernetes", version = "1.29.13.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra != 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.29.13.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
     { name = "cloudcoil-models-kubernetes", version = "1.30.9.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-30' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
     { name = "cloudcoil-models-kubernetes", version = "1.31.5.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
-    { name = "cloudcoil-models-kubernetes", version = "1.32.1.1", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.32.1.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra != 'extra-9-cloudcoil-kubernetes-1-31')" },
 ]
 codegen = [
     { name = "datamodel-code-generator", extra = ["http"] },
     { name = "ruff" },
 ]
 kubernetes = [
-    { name = "cloudcoil-models-kubernetes", version = "1.29.13.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra != 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.29.13.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
     { name = "cloudcoil-models-kubernetes", version = "1.30.9.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-30' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
     { name = "cloudcoil-models-kubernetes", version = "1.31.5.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
-    { name = "cloudcoil-models-kubernetes", version = "1.32.1.1", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.32.1.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra != 'extra-9-cloudcoil-kubernetes-1-31')" },
 ]
 kubernetes-1-29 = [
     { name = "cloudcoil-models-kubernetes", version = "1.29.13.1", source = { registry = "https://pypi.org/simple" } },
@@ -226,6 +226,10 @@ test = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "cloudcoil-models-kubernetes", version = "1.29.13.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.30.9.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-30' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.31.5.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.32.1.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-32' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra != 'extra-9-cloudcoil-kubernetes-1-31')" },
     { name = "datamodel-code-generator", extra = ["http"] },
     { name = "ipython" },
     { name = "mkdocs" },
@@ -262,6 +266,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "cloudcoil-models-kubernetes", specifier = ">=1.29.13.1" },
     { name = "datamodel-code-generator", extras = ["http"] },
     { name = "ipython", specifier = ">=8.12.3" },
     { name = "mkdocs", specifier = ">=1.6.1" },
@@ -291,7 +296,7 @@ resolution-markers = [
     "python_full_version >= '4.0'",
 ]
 dependencies = [
-    { name = "cloudcoil" },
+    { name = "cloudcoil", marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/20/5789ed6a4f3cee3a99e3813762da9bc9cf66bad1d658c1db859d4a64e2a2/cloudcoil_models_kubernetes-1.29.13.1.tar.gz", hash = "sha256:d681fe97f014d2e5c7da0310ac1a6af45d417be8120071459a69183945a4d87c", size = 262551 }
 wheels = [
@@ -345,7 +350,7 @@ resolution-markers = [
     "python_full_version >= '4.0'",
 ]
 dependencies = [
-    { name = "cloudcoil", marker = "(extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/bc/fd75c66074c02eae6dfdcb1307f4db7e82990b797f272341cbf705c40e17/cloudcoil_models_kubernetes-1.32.1.1.tar.gz", hash = "sha256:4df2454c1c06992fcd9b530d10f4ac1a674447626d4c7cde460e557eb7fcb37d", size = 289284 }
 wheels = [


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and documentation of the CloudCoil project. The most significant changes include updates to the `README.md` file to provide more comprehensive examples and usage patterns, enhancements to the `cloudcoil/codegen/generator.py` file to support new features, and minor fixes to the `Makefile` and template files.

Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14-R14): Added detailed examples on building Kubernetes resources using models, fluent builder API, and context manager builder API. Updated the link to the cookiecutter template. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14-R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R75-R314) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L349-R589)

Code generation enhancements:

* [`cloudcoil/codegen/generator.py`](diffhunk://#diff-e20a70c20872264a870680b7b56b68e61f1bb2e5317c1275afc3a94739cbb218L42-R43): Introduced a new `delete_value_at_path` function to support deleting values at specified JSON paths. Updated `set_value_at_path` to handle empty array slots. Modified `process_updates` to handle delete operations. Simplified the `rename_classes` function to use regex patterns for renaming classes. [[1]](diffhunk://#diff-e20a70c20872264a870680b7b56b68e61f1bb2e5317c1275afc3a94739cbb218L42-R43) [[2]](diffhunk://#diff-e20a70c20872264a870680b7b56b68e61f1bb2e5317c1275afc3a94739cbb218R165-R323) [[3]](diffhunk://#diff-e20a70c20872264a870680b7b56b68e61f1bb2e5317c1275afc3a94739cbb218R383-R385) [[4]](diffhunk://#diff-e20a70c20872264a870680b7b56b68e61f1bb2e5317c1275afc3a94739cbb218L345-L347) [[5]](diffhunk://#diff-e20a70c20872264a870680b7b56b68e61f1bb2e5317c1275afc3a94739cbb218L773-R869)

Minor fixes:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L13-R14): Fixed a minor issue in the `fix-lint` target by removing an unnecessary period.
* [`cloudcoil/codegen/templates/pydantic_v2/BaseModel.jinja2`](diffhunk://#diff-1ec40bf99182f1b718f59e8cc58139f928ed6abe7ef19337a1617e484eb780f2L14-R14): Replaced tabs with spaces in docstrings to ensure consistent indentation. [[1]](diffhunk://#diff-1ec40bf99182f1b718f59e8cc58139f928ed6abe7ef19337a1617e484eb780f2L14-R14) [[2]](diffhunk://#diff-1ec40bf99182f1b718f59e8cc58139f928ed6abe7ef19337a1617e484eb780f2L44-R44)