### PR TITLE
Add sealed secrets and add supports for multiple crd inputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ gen-repo-%:
 publish-repo-%: gen-repo-%
 	@echo "Publishing to cloudcoil/models-$*"
 	@if ! gh repo view cloudcoil/models-$* >/dev/null 2>&1; then \
-		gh repo create cloudcoil/models-$* --add-readme --public --description "Generated model repository for $*"; \
+		gh repo create cloudcoil/models-$* --add-readme --public --description "Generated model repository for $*" && gh repo edit --add-topic cloudcoil --add-topic cloudcoil-models cloudcoil/models-$*; \
 	fi
 	@rm -rf tmp/models-$*
 	@mkdir -p tmp/models-$*

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Current first-class integrations include:
 | [knative-eventing](https://github.com/knative/eventing) | [models-knative-eventing](https://github.com/cloudcoil/models-knative-eventing) | [cloudcoil.models.knative_eventing](https://pypi.org/project/cloudcoil.models.knative-eventing) |
 | [kyverno](https://github.com/kyverno/kyverno) | [models-kyverno](https://github.com/cloudcoil/models-kyverno) | [cloudcoil.models.kyverno](https://pypi.org/project/cloudcoil.models.kyverno) |
 | [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator) | [models-prometheus-operator](https://github.com/cloudcoil/models-prometheus-operator) | [cloudcoil.models.prometheus_operator](https://pypi.org/project/cloudcoil.models.prometheus_operator) |
-
+| [sealed-secrets](https://github.com/bitnami-labs/sealed-secrets) | [models-sealed-secrets](https://github.com/cloudcoil/models-sealed-secrets) | [cloudcoil.models.sealed_secrets](https://pypi.org/project/cloudcoil.models.sealed_secrets) |
 
 You can install these integrations using
 

--- a/cookiecutter/cookiecutter.json
+++ b/cookiecutter/cookiecutter.json
@@ -4,7 +4,7 @@
     "author_name": "Sambhav Kothari",
     "author_email": "sambhavs.email@gmail.com",
     "crd_namespace": "default",
-    "crd_url": "https://example.com",
+    "crd_urls": "https://example.com",
     "versions": "'1.0.0', '1.0.1', '1.0.2'",
     "version_replacement_sed": "releases/download/v",
     "_config_dir": ""

--- a/cookiecutter/models-{{ cookiecutter.model_name }}/pyproject.toml
+++ b/cookiecutter/models-{{ cookiecutter.model_name }}/pyproject.toml
@@ -81,7 +81,12 @@ only-include = ["cloudcoil"]
 # Unique name for the models
 # This will be used as the name for the setuptools entrypoints
 namespace = "cloudcoil.models.{{cookiecutter.module_name}}"
-input = "{{ cookiecutter.crd_url }}"
+# Split the crl urls by comma
+input = [
+{%- for crd in cookiecutter.crd_urls.split(',') %}
+    "{{ crd | trim }}",
+{%- endfor %}
+]
 {%- if cookiecutter.crd_namespace %}
 crd-namespace = "{{ cookiecutter.crd_namespace }}"
 {%- endif %}

--- a/models/cert-manager/cookiecutter.yaml
+++ b/models/cert-manager/cookiecutter.yaml
@@ -3,6 +3,6 @@ default_context:
   author_name: Sambhav Kothari
   author_email: sambhavs.email@gmail.com
   crd_namespace: io.cert-manager
-  crd_url: https://github.com/cert-manager/cert-manager/releases/download/v1.16.3/cert-manager.crds.yaml
+  crd_urls: https://github.com/cert-manager/cert-manager/releases/download/v1.16.3/cert-manager.crds.yaml
   versions: "'1.16.3'"
   version_replacement_sed: releases/download/v

--- a/models/fluxcd/cookiecutter.yaml
+++ b/models/fluxcd/cookiecutter.yaml
@@ -3,6 +3,6 @@ default_context:
   author_name: Sambhav Kothari
   author_email: sambhavs.email@gmail.com
   crd_namespace: io.fluxcd.toolkit
-  crd_url: https://github.com/fluxcd/flux2/releases/download/v2.4.0/install.yaml
+  crd_urls: https://github.com/fluxcd/flux2/releases/download/v2.4.0/install.yaml
   versions: "'2.4.0'"
   version_replacement_sed: releases/download/v

--- a/models/istio/cookiecutter.yaml
+++ b/models/istio/cookiecutter.yaml
@@ -3,6 +3,6 @@ default_context:
   author_name: Sambhav Kothari
   author_email: sambhavs.email@gmail.com
   crd_namespace: io.istio
-  crd_url: https://raw.githubusercontent.com/istio/istio/refs/tags/1.24.2/manifests/charts/base/files/crd-all.gen.yaml
+  crd_urls: https://raw.githubusercontent.com/istio/istio/refs/tags/1.24.2/manifests/charts/base/files/crd-all.gen.yaml
   versions: "'1.24.2'"
   version_replacement_sed: refs/tags/

--- a/models/knative-eventing/cookiecutter.yaml
+++ b/models/knative-eventing/cookiecutter.yaml
@@ -3,6 +3,6 @@ default_context:
   author_name: Sambhav Kothari
   author_email: sambhavs.email@gmail.com
   crd_namespace: dev.knative
-  crd_url: https://github.com/knative/eventing/releases/download/knative-v1.17.1/eventing-crds.yaml
+  crd_urls: https://github.com/knative/eventing/releases/download/knative-v1.17.1/eventing-crds.yaml
   versions: "'1.17.1'"
   version_replacement_sed: releases/download/knative-v

--- a/models/knative-serving/cookiecutter.yaml
+++ b/models/knative-serving/cookiecutter.yaml
@@ -3,6 +3,6 @@ default_context:
   author_name: Sambhav Kothari
   author_email: sambhavs.email@gmail.com
   crd_namespace: dev.knative
-  crd_url: https://github.com/knative/serving/releases/download/knative-v1.17.0/serving-crds.yaml
+  crd_urls: https://github.com/knative/serving/releases/download/knative-v1.17.0/serving-crds.yaml
   versions: "'1.17.0'"
   version_replacement_sed: releases/download/knative-v

--- a/models/kubernetes/cookiecutter.yaml
+++ b/models/kubernetes/cookiecutter.yaml
@@ -3,6 +3,6 @@ default_context:
   author_name: Sambhav Kothari
   author_email: sambhavs.email@gmail.com
   crd_namespace: ''
-  crd_url: https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.32.1/api/openapi-spec/swagger.json
+  crd_urls: https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v1.32.1/api/openapi-spec/swagger.json
   versions: "'1.29.13', '1.30.9', '1.31.5', '1.32.1'"
   version_replacement_sed: refs/tags/v

--- a/models/kyverno/cookiecutter.yaml
+++ b/models/kyverno/cookiecutter.yaml
@@ -3,6 +3,6 @@ default_context:
   author_name: Sambhav Kothari
   author_email: sambhavs.email@gmail.com
   crd_namespace: io.kyverno
-  crd_url: https://github.com/kyverno/kyverno/releases/download/v1.12.7/install.yaml
+  crd_urls: https://github.com/kyverno/kyverno/releases/download/v1.12.7/install.yaml
   versions: "'1.12.7'"
   version_replacement_sed: releases/download/v

--- a/models/prometheus-operator/cookiecutter.yaml
+++ b/models/prometheus-operator/cookiecutter.yaml
@@ -3,6 +3,6 @@ default_context:
   author_name: Sambhav Kothari
   author_email: sambhavs.email@gmail.com
   crd_namespace: com.coreos.monitoring
-  crd_url: https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.79.2/bundle.yaml
+  crd_urls: https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.79.2/bundle.yaml
   versions: "'0.79.2'"
   version_replacement_sed: releases/download/v

--- a/models/sealed-secrets/README.md
+++ b/models/sealed-secrets/README.md
@@ -1,0 +1,109 @@
+> [!WARNING]  
+> This repository is auto-generated from the [cloudcoil repository](https://github.com/cloudcoil/cloudcoil/tree/main/models/sealed-secrets). Please do not submit pull requests here. Instead, submit them to the main repository at https://github.com/cloudcoil/cloudcoil.
+
+## 🔧 Installation
+
+> [!NOTE]
+> For versioning information and compatibility, see the [Versioning Guide](https://github.com/cloudcoil/cloudcoil/blob/main/VERSIONING.md).
+
+Using [uv](https://github.com/astral-sh/uv) (recommended):
+
+```bash
+# Install with Sealed Secrets support
+uv add cloudcoil.models.sealed-secrets
+```
+
+Using pip:
+
+```bash
+pip install cloudcoil.models.sealed-secrets
+```
+
+## 💡 Examples
+
+### Using Sealed Secrets Models
+
+```python
+from cloudcoil import apimachinery
+import cloudcoil.models.sealed_secrets.v1alpha1 as sealed_secrets
+
+# Create a SealedSecret
+sealed_secret = sealed_secrets.SealedSecret(
+    metadata=apimachinery.ObjectMeta(name="mysecret"),
+    spec=sealed_secrets.SealedSecretSpec(
+        encrypted_data={
+            "username": "AgBy8hCi8...",  # Your encrypted data here
+            "password": "AgBy8hCi8..."   # Your encrypted data here
+        }
+    )
+).create()
+
+# List SealedSecrets
+for secret in sealed_secrets.SealedSecret.list():
+    print(f"Found SealedSecret: {secret.metadata.name}")
+```
+
+### Using the Fluent Builder API
+
+Cloudcoil provides a powerful fluent builder API for Sealed Secrets resources:
+
+```python
+from cloudcoil.models.sealed_secrets.v1alpha1 import SealedSecret
+
+# Create a SealedSecret using the fluent builder
+sealed_secret = (
+    SealedSecret.builder()
+    .metadata(lambda metadata: metadata
+        .name("mysecret")
+        .namespace("default")
+        .labels({"app": "myapp"})
+    )
+    .spec(lambda spec: spec
+        .encrypted_data({
+            "username": "AgBy8hCi8...",  # Your encrypted data here
+            "password": "AgBy8hCi8..."   # Your encrypted data here
+        })
+        .template(lambda template: template
+            .metadata(lambda t_metadata: t_metadata
+                .labels({"app": "myapp"})
+            )
+            .type("Opaque")
+        )
+    )
+    .build()
+)
+```
+
+### Using the Context Manager Builder API
+
+For complex sealed secret configurations, you can use the context manager-based builder:
+
+```python
+from cloudcoil.models.sealed_secrets.v1alpha1 import SealedSecret
+
+# Create a SealedSecret using context managers
+with SealedSecret.new() as secret:
+    with secret.metadata() as metadata:
+        metadata.name("mysecret")
+        metadata.namespace("default")
+    
+    with secret.spec() as spec:
+        spec.encrypted_data({
+            "username": "AgBy8hCi8...",  # Your encrypted data here
+            "password": "AgBy8hCi8..."   # Your encrypted data here
+        })
+        with spec.template() as template:
+            template.type("Opaque")
+            with template.metadata() as t_metadata:
+                t_metadata.labels({"app": "myapp"})
+
+final_secret = secret.build()
+```
+
+## 📚 Documentation
+
+For complete documentation, visit [cloudcoil.github.io/cloudcoil](https://cloudcoil.github.io/cloudcoil)
+
+## 📜 License
+
+Apache License, Version 2.0 - see [LICENSE](LICENSE)

--- a/models/sealed-secrets/cookiecutter.yaml
+++ b/models/sealed-secrets/cookiecutter.yaml
@@ -1,0 +1,8 @@
+default_context:
+  model_name: sealed-secrets
+  author_name: Sambhav Kothari
+  author_email: sambhavs.email@gmail.com
+  crd_namespace: com.bitnami
+  crd_urls: https://raw.githubusercontent.com/bitnami-labs/sealed-secrets/refs/tags/v0.28.0/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
+  versions: "'0.28.0'"
+  version_replacement_sed: refs/tags/v


### PR DESCRIPTION
This pull request includes several changes to improve the handling of multiple CRD URLs and enhance the documentation for the `sealed-secrets` model. The most important changes include modifying the `ModelConfig` class to support a list of input URLs, updating the `process_input` function to handle multiple inputs, and adding comprehensive documentation for the `sealed-secrets` model.

Changes to support multiple CRD URLs:

* [`cloudcoil/codegen/generator.py`](diffhunk://#diff-e20a70c20872264a870680b7b56b68e61f1bb2e5317c1275afc3a94739cbb218L85-R85): Modified the `ModelConfig` class to support a list of input URLs instead of a single URL. Updated the `process_input` function to handle multiple inputs, including fetching and processing content from both remote and local sources. [[1]](diffhunk://#diff-e20a70c20872264a870680b7b56b68e61f1bb2e5317c1275afc3a94739cbb218L85-R85) [[2]](diffhunk://#diff-e20a70c20872264a870680b7b56b68e61f1bb2e5317c1275afc3a94739cbb218R547-R577)

Updates to configuration files:

* [`cookiecutter/cookiecutter.json`](diffhunk://#diff-2c36d8b2788410001c86a72b99ebd493328cf62e5bb23a8ccbb0b8152c69314dL7-R7): Changed `crd_url` to `crd_urls` to reflect the support for multiple URLs.
* Various model-specific `cookiecutter.yaml` files: Updated the `crd_url` field to `crd_urls` for models such as `cert-manager`, `fluxcd`, `istio`, `knative-eventing`, `knative-serving`, `kubernetes`, `kyverno`, and `prometheus-operator`. [[1]](diffhunk://#diff-03175c5d2f01d414410310eac8500dd700ecade79621c5809f076c73a6176057L6-R6) [[2]](diffhunk://#diff-7061c36dc64937a4484115fa159b8a5c60eeafef6f9c1af74671214d90b233e2L6-R6) [[3]](diffhunk://#diff-6c0ba5abfbbbbcc8d8f406a5b411dd9609620d28c26dbef27d04e750b9d9846dL6-R6) [[4]](diffhunk://#diff-1fcf3c5d3c9d49ad6c8c9dfd70873504dd17571fe8fa7e992c7a7d812d1ece66L6-R6) [[5]](diffhunk://#diff-2bf6082b73b64a95073ab383980b086b6019856583c8bcec1a2caa556b900239L6-R6) [[6]](diffhunk://#diff-3f72677855c3df1d7e11192d21b3f960cad08f4d689d43e5d0abe56f5bc93c88L6-R6) [[7]](diffhunk://#diff-df4e58366043e0bf9da78b3b414a57d427dc130203845c4a5eb2b0ac5932cf1eL6-R6) [[8]](diffhunk://#diff-ca02300f532da09d6fa022791c0d317e25176ad7dcf3b79231ee3f4ad566792eL6-R6)

Documentation enhancements:

* [`models/sealed-secrets/README.md`](diffhunk://#diff-2d17b0107cffc16e1c382bbe724bb3771de5261a9cbd4291d103dd91bf0f385fR1-R176): Added detailed installation instructions, examples, and documentation for using the `sealed-secrets` model with different builder APIs.
* [`models/sealed-secrets/cookiecutter.yaml`](diffhunk://#diff-174c0bbdade15c1ab93f3fd1cdb4d8756a84b5340e2ae44a695ec7d288a56dcaR1-R8): Added a new `cookiecutter.yaml` file for the `sealed-secrets` model, specifying the default context and CRD URLs.

Repository management:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L61-R61): Updated the `publish-repo-%` target to add topics to the repository when creating it.

Fixes #72 