### PR TITLE
Add velero and all-models extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
       - name: Install dependencies
-        run: uv sync --extra all --dev
+        run: uv sync --extra kubernetes --dev
 
       - name: Run Checks
         run: make lint test
@@ -101,7 +101,7 @@ jobs:
           cache-dependency-glob: "**/uv.lock"
 
       - name: Install dependencies
-        run: uv sync --extra all --dev
+        run: uv sync --extra kubernetes --dev
 
       - name: Run Checks
         run: make lint test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,6 @@ jobs:
           cache-dependency-glob: "**/uv.lock"
 
       - name: Install dependencies
-        run: uv sync --extra all --dev
+        run: uv sync --extra kubernetes --dev
       - name: Deploy docs
         run: make docs-deploy

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -28,7 +28,7 @@
               cache-dependency-glob: "**/uv.lock"
     
           - name: Install dependencies
-            run: uv sync --extra all --dev
+            run: uv sync --extra kubernetes --dev
     
           - name: Bump version number
             run: |

--- a/.github/workflows/test_pypi_publish.yml
+++ b/.github/workflows/test_pypi_publish.yml
@@ -28,7 +28,7 @@
               cache-dependency-glob: "**/uv.lock"
     
           - name: Install dependencies
-            run: uv sync --extra all --dev
+            run: uv sync --extra kubernetes --dev
     
           - name: Bump version number
             run: |

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ You can install these integrations using
 uv add cloudcoil[kyverno]
 # You can also install multiple dependencies at once
 uv add cloudcoil[cert-manager,fluxcd,kyverno]
+# You can also install all available models in cloudcoil using
+uv add cloudcoil[all-models]
 ```
 
 > Missing an integration you need? [Open a model request](https://github.com/cloudcoil/cloudcoil/issues/new?template=%F0%9F%94%8C-model-request.md) to suggest a new integration!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,20 +27,32 @@ cloudcoil-model-codegen = "cloudcoil.codegen.generator:main"
 [project.optional-dependencies]
 test = ["pytest"]
 codegen = ["datamodel-code-generator[http]~=0.26.4", "ruff"]
-kubernetes = ["cloudcoil.models.kubernetes"]
-kubernetes-1-32 = ["cloudcoil.models.kubernetes~=1.32.0"]
-kubernetes-1-31 = ["cloudcoil.models.kubernetes~=1.31.0"]
-kubernetes-1-30 = ["cloudcoil.models.kubernetes~=1.30.0"]
-kubernetes-1-29 = ["cloudcoil.models.kubernetes~=1.29.0"]
-kyverno = ["cloudcoil.models.kyverno"]
-istio = ["cloudcoil.models.istio"]
 cert-manager = ["cloudcoil.models.cert_manager"]
 fluxcd = ["cloudcoil.models.fluxcd"]
-prometheus-operator = ["cloudcoil.models.prometheus_operator"]
-knative-serving = ["cloudcoil.models.knative_serving"]
+istio = ["cloudcoil.models.istio"]
 knative-eventing = ["cloudcoil.models.knative_eventing"]
+knative-serving = ["cloudcoil.models.knative_serving"]
+kubernetes = ["cloudcoil.models.kubernetes"]
+kubernetes-1-29 = ["cloudcoil.models.kubernetes~=1.29.0"]
+kubernetes-1-30 = ["cloudcoil.models.kubernetes~=1.30.0"]
+kubernetes-1-31 = ["cloudcoil.models.kubernetes~=1.31.0"]
+kubernetes-1-32 = ["cloudcoil.models.kubernetes~=1.32.0"]
+kyverno = ["cloudcoil.models.kyverno"]
+prometheus-operator = ["cloudcoil.models.prometheus_operator"]
 sealed-secrets = ["cloudcoil.models.sealed_secrets"]
-all = ["cloudcoil.models.kubernetes"]
+velero = ["cloudcoil.models.velero"]
+all-models = [
+    "cloudcoil.models.cert_manager",
+    "cloudcoil.models.fluxcd",
+    "cloudcoil.models.istio",
+    "cloudcoil.models.knative_eventing",
+    "cloudcoil.models.knative_serving",
+    "cloudcoil.models.kubernetes",
+    "cloudcoil.models.kyverno",
+    "cloudcoil.models.prometheus_operator",
+    "cloudcoil.models.sealed_secrets",
+    "cloudcoil.models.velero",
+]
 
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -198,6 +198,21 @@ all = [
     { name = "cloudcoil-models-kubernetes", version = "1.31.5.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
     { name = "cloudcoil-models-kubernetes", version = "1.32.1.1", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
 ]
+all-models = [
+    { name = "cloudcoil-models-cert-manager" },
+    { name = "cloudcoil-models-fluxcd" },
+    { name = "cloudcoil-models-istio" },
+    { name = "cloudcoil-models-knative-eventing" },
+    { name = "cloudcoil-models-knative-serving" },
+    { name = "cloudcoil-models-kubernetes", version = "1.29.13.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-29' or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra != 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.30.9.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-30' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.31.5.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-cloudcoil-kubernetes-1-31' or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kubernetes", version = "1.32.1.1", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-30') or (extra == 'extra-9-cloudcoil-kubernetes-1-29' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra == 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-31') or (extra != 'extra-9-cloudcoil-kubernetes-1-31' and extra == 'extra-9-cloudcoil-kubernetes-1-32') or (extra != 'extra-9-cloudcoil-kubernetes-1-29' and extra != 'extra-9-cloudcoil-kubernetes-1-30' and extra == 'extra-9-cloudcoil-kubernetes-1-32')" },
+    { name = "cloudcoil-models-kyverno" },
+    { name = "cloudcoil-models-prometheus-operator" },
+    { name = "cloudcoil-models-sealed-secrets" },
+    { name = "cloudcoil-models-velero" },
+]
 cert-manager = [
     { name = "cloudcoil-models-cert-manager" },
 ]
@@ -241,8 +256,14 @@ kyverno = [
 prometheus-operator = [
     { name = "cloudcoil-models-prometheus-operator" },
 ]
+sealed-secrets = [
+    { name = "cloudcoil-models-sealed-secrets" },
+]
 test = [
     { name = "pytest" },
+]
+velero = [
+    { name = "cloudcoil-models-velero" },
 ]
 
 [package.dev-dependencies]
@@ -270,19 +291,31 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cloudcoil-models-cert-manager", marker = "extra == 'all-models'" },
     { name = "cloudcoil-models-cert-manager", marker = "extra == 'cert-manager'" },
+    { name = "cloudcoil-models-fluxcd", marker = "extra == 'all-models'" },
     { name = "cloudcoil-models-fluxcd", marker = "extra == 'fluxcd'" },
+    { name = "cloudcoil-models-istio", marker = "extra == 'all-models'" },
     { name = "cloudcoil-models-istio", marker = "extra == 'istio'" },
+    { name = "cloudcoil-models-knative-eventing", marker = "extra == 'all-models'" },
     { name = "cloudcoil-models-knative-eventing", marker = "extra == 'knative-eventing'" },
+    { name = "cloudcoil-models-knative-serving", marker = "extra == 'all-models'" },
     { name = "cloudcoil-models-knative-serving", marker = "extra == 'knative-serving'" },
     { name = "cloudcoil-models-kubernetes", marker = "extra == 'all'" },
+    { name = "cloudcoil-models-kubernetes", marker = "extra == 'all-models'" },
     { name = "cloudcoil-models-kubernetes", marker = "extra == 'kubernetes'" },
     { name = "cloudcoil-models-kubernetes", marker = "extra == 'kubernetes-1-29'", specifier = "~=1.29.0" },
     { name = "cloudcoil-models-kubernetes", marker = "extra == 'kubernetes-1-30'", specifier = "~=1.30.0" },
     { name = "cloudcoil-models-kubernetes", marker = "extra == 'kubernetes-1-31'", specifier = "~=1.31.0" },
     { name = "cloudcoil-models-kubernetes", marker = "extra == 'kubernetes-1-32'", specifier = "~=1.32.0" },
+    { name = "cloudcoil-models-kyverno", marker = "extra == 'all-models'" },
     { name = "cloudcoil-models-kyverno", marker = "extra == 'kyverno'" },
+    { name = "cloudcoil-models-prometheus-operator", marker = "extra == 'all-models'" },
     { name = "cloudcoil-models-prometheus-operator", marker = "extra == 'prometheus-operator'" },
+    { name = "cloudcoil-models-sealed-secrets", marker = "extra == 'all-models'" },
+    { name = "cloudcoil-models-sealed-secrets", marker = "extra == 'sealed-secrets'" },
+    { name = "cloudcoil-models-velero", marker = "extra == 'all-models'" },
+    { name = "cloudcoil-models-velero", marker = "extra == 'velero'" },
     { name = "datamodel-code-generator", extras = ["http"], marker = "extra == 'codegen'", specifier = "~=0.26.4" },
     { name = "httpx" },
     { name = "pydantic", specifier = ">2.0" },
@@ -467,6 +500,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/a2/22123891dd71a7f2d49fa3e6189e28b1294d1e542faa4e395fa13fa72fc6/cloudcoil_models_prometheus_operator-0.79.2.0.tar.gz", hash = "sha256:f0b495140b105875b3b8093f08ae453106ea90eea4f9115b8167b5fdf06ec294", size = 445631 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/3b/e29d59c6fa047ceb48b8b186004e5a5272085a75e6a890537bc209559e5d/cloudcoil_models_prometheus_operator-0.79.2.0-py3-none-any.whl", hash = "sha256:a40cca1adad11e4a051227661247fc27b5c35b69b50b8b4d9766f213a7ff6b87", size = 389453 },
+]
+
+[[package]]
+name = "cloudcoil-models-sealed-secrets"
+version = "0.28.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudcoil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/65/8105b9529463e34db4e5b1a09d8f799f7595ebc6c3e121bf46fef8288c14/cloudcoil_models_sealed_secrets-0.28.0.0.tar.gz", hash = "sha256:dc39284d33418c2fc78af7565deedd6262442b36a18235351b0f1a1b5f0e5fa8", size = 72026 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/eb/ebcfdcbb345f5e2e8185282c5e16c1c1f4a0509800af180750da6cfa5ea7/cloudcoil_models_sealed_secrets-0.28.0.0-py3-none-any.whl", hash = "sha256:e950bf84ea6fa80541afcc5e38c5e4a15f9ef4aee8e2c5426090b40b23f132c8", size = 10256 },
+]
+
+[[package]]
+name = "cloudcoil-models-velero"
+version = "1.15.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudcoil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/8b/ef6399eb2c8089dd12c23f493fa4202356984ff61cfcb8d9f1b8385db9b6/cloudcoil_models_velero-1.15.2.0.tar.gz", hash = "sha256:8849534e9bc5df96399738ba029737dc3425da4de74f0dd28efa13a0aeb38d25", size = 99848 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/fb/9352291911e8a1a503a3dc9e62490472e719b24ffe3f6138b63a09b2f635/cloudcoil_models_velero-1.15.2.0-py3-none-any.whl", hash = "sha256:9b2dd895081fe3bb2395c4c1ec45fa09496031dc8d1d898ced2b20505cf515b7", size = 38632 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request includes several changes to the CI/CD workflows, documentation, and dependencies in the project. The most important changes include updating the dependencies in various workflow files, adding a new option to install all available models in the `README.md`, and reorganizing the `pyproject.toml` file to include new model dependencies.

### Workflow updates:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL34-R34): Changed the `uv sync` command to use `--extra kubernetes --dev` instead of `--extra all --dev` for installing dependencies. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL34-R34) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL104-R104)
* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL28-R28): Updated the `uv sync` command to use `--extra kubernetes --dev` for installing dependencies.
* [`.github/workflows/pypi_publish.yml`](diffhunk://#diff-e63c5d93f83e5bdcd906866da663fe90cbb5d5132b0b7b59c546b5c652e36fa9L31-R31): Modified the `uv sync` command to use `--extra kubernetes --dev` for installing dependencies.
* [`.github/workflows/test_pypi_publish.yml`](diffhunk://#diff-8e58709e95297ef23b842c0100526f5cc686820dc24102f66287f74785f1fd8aL31-R31): Changed the `uv sync` command to use `--extra kubernetes --dev` for installing dependencies.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R75-R76): Added a new option to install all available models in cloudcoil using `uv add cloudcoil[all-models]`.

### Dependency updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R30-R55): Reorganized and added new model dependencies, including `cert-manager`, `fluxcd`, `istio`, `knative-eventing`, `knative-serving`, and `velero`. Also added a new `all-models` option that includes all available models.