### PR TITLE
Add kpack model

### DIFF
--- a/cloudcoil/codegen/templates/pydantic_v2/BaseModel.jinja2
+++ b/cloudcoil/codegen/templates/pydantic_v2/BaseModel.jinja2
@@ -152,7 +152,7 @@ class {{ class_name }}(BaseModel):{% if comment is defined %}  # {{ comment }}{%
     {{ field.name }}: {{ field.type_hint }}
     {%- endif %}
     {%- if not (field.required or (field.represented_default == 'None' and field.strip_default_none)) or field.data_type.is_optional
-            %} = {{ field.represented_default }}
+            %} = {% if field.represented_default == "{}" and field.data_type.reference is not none %}{{ field.data_type.type_hint }}.model_validate({{ field.represented_default }}){% else %}{{ field.represented_default }}{% endif %}
     {%- endif -%}
     {%- endif %}
     {%- if field.docstring %}

--- a/cookiecutter/cookiecutter.json
+++ b/cookiecutter/cookiecutter.json
@@ -7,5 +7,6 @@
     "crd_urls": "https://example.com",
     "versions": "'1.0.0', '1.0.1', '1.0.2'",
     "version_replacement_sed": "releases/download/v",
+    "dependencies": "",
     "_config_dir": ""
 }

--- a/cookiecutter/models-{{ cookiecutter.model_name }}/pyproject.toml
+++ b/cookiecutter/models-{{ cookiecutter.model_name }}/pyproject.toml
@@ -15,6 +15,9 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "cloudcoil>=0.4.0",
+{%- for dependency in cookiecutter.dependencies.split(',') %}
+    "{{ dependency | trim }}",
+{%- endfor %}
 ]
 keywords = ["cloud-native", "kubernetes", "{{ cookiecutter.model_name}}", "pydantic", "python", "async", "cloudcoil", "cloudcoil-models"]
 

--- a/models/kpack/README.md
+++ b/models/kpack/README.md
@@ -1,0 +1,171 @@
+> [!WARNING]  
+> This repository is auto-generated from the [cloudcoil repository](https://github.com/cloudcoil/cloudcoil/tree/main/models/kpack). Please do not submit pull requests here. Instead, submit them to the main repository at https://github.com/cloudcoil/cloudcoil.
+
+## 🔧 Installation
+
+> [!NOTE]
+> For versioning information and compatibility, see the [Versioning Guide](https://github.com/cloudcoil/cloudcoil/blob/main/VERSIONING.md).
+
+Using [uv](https://github.com/astral-sh/uv) (recommended):
+
+```bash
+# Install with kpack support
+uv add cloudcoil.models.kpack
+```
+
+Using pip:
+
+```bash
+pip install cloudcoil.models.kpack
+```
+
+## 💡 Examples
+
+### Using kpack Models
+
+```python
+from cloudcoil import apimachinery
+import cloudcoil.models.kpack.build.v1alpha2 as kpack
+import cloudcoil.models.kpack.core.v1alpha1 as core
+import cloudcoil.models.kubernetes.core.v1 as k8score
+
+# Create an Image resource
+image = kpack.Image(
+    metadata=apimachinery.ObjectMeta(name="my-app"),
+    spec=kpack.ImageSpec(
+        tag="registry.example.com/my-app",
+        builder_=k8score.ObjectReference(
+            name="my-builder",
+            kind="ClusterBuilder"
+        ),
+        source=core.SourceConfig(
+            git=core.Git(
+                url="https://github.com/my-org/my-app.git",
+                revision="main"
+            )
+        )
+    )
+).create()
+
+# Create a Builder
+builder = kpack.BuilderResource(
+    metadata=apimachinery.ObjectMeta(name="my-builder"),
+    spec=kpack.BuilderSpec(
+        tag="registry.example.com/builder",
+        stack=k8score.ObjectReference(
+            name="base",
+            kind="ClusterStack"
+        ),
+        store=k8score.ObjectReference(
+            name="default",
+            kind="ClusterStore"
+        )
+    )
+).create()
+
+# List Images
+for img in kpack.Image.list():
+    print(f"Found image: {img.metadata.name}")
+
+# Update an Image
+image.spec.source.git.revision = "v1.0.0"
+image.save()
+
+# Delete resources
+kpack.Image.delete("my-app")
+kpack.BuilderResource.delete("my-builder")
+```
+
+### Using the Fluent Builder API
+
+```python
+from cloudcoil.models.kpack.build.v1alpha2 import Image
+
+# Create an Image using the fluent builder
+image = (
+    Image.builder()
+    .metadata(lambda m: m
+        .name("my-app")
+        .namespace("default")
+    )
+    .spec(lambda s: s
+        .tag("registry.example.com/my-app")
+        .builder_(lambda b: b
+            .name("my-builder")
+            .kind("ClusterBuilder")
+        )
+        .source(lambda src: src
+            .git(lambda g: g
+                .url("https://github.com/my-org/my-app.git")
+                .revision("main")
+            )
+        )
+    )
+    .build()
+)
+```
+
+### Using the Context Manager Builder API
+
+```python
+from cloudcoil.models.kpack.build.v1alpha2 import Image, BuilderResource
+
+# Create an image using context managers
+with Image.new() as app_image:
+    with app_image.metadata() as metadata:
+        metadata.name("my-app")
+        metadata.namespace("default")
+    
+    with app_image.spec() as spec:
+        spec.tag("registry.example.com/my-app")
+        
+        with spec.builder_() as builder:
+            builder.name("my-builder")
+            builder.kind("ClusterBuilder")
+        
+        with spec.source() as source:
+            with source.git() as git:
+                git.url("https://github.com/my-org/my-app.git")
+                git.revision("main")
+
+final_image = app_image.build()
+
+# Create a builder using context managers
+with BuilderResource.new() as builder:
+    with builder.metadata() as metadata:
+        metadata.name("my-builder")
+        metadata.namespace("default")
+    
+    with builder.spec() as spec:
+        spec.tag("registry.example.com/builder")
+        
+        with spec.stack() as stack:
+            stack.name("base")
+            stack.kind("ClusterStack")
+        
+        with spec.store() as store:
+            store.name("default")
+            store.kind("ClusterStore")
+        
+        # Add buildpacks to the builder
+        with spec.buildpacks() as buildpacks:
+            with buildpacks.add() as pack:
+                pack.id("paketo-buildpacks/java")
+                pack.version("3.0.0")
+
+final_builder = builder.build()
+```
+
+The context manager builder provides:
+- 🎭 Clear visual nesting of resource structure
+- 🔒 Automatic resource cleanup
+- 🎯 Familiar Python context manager pattern
+- ✨ Same great IDE support as the fluent builder
+
+## 📚 Documentation
+
+For complete documentation, visit [cloudcoil.github.io/cloudcoil](https://cloudcoil.github.io/cloudcoil)
+
+## 📜 License
+
+Apache License, Version 2.0 - see [LICENSE](LICENSE)

--- a/models/kpack/cookiecutter.yaml
+++ b/models/kpack/cookiecutter.yaml
@@ -1,0 +1,9 @@
+default_context:
+  model_name: kpack
+  author_name: Sambhav Kothari
+  author_email: sambhavs.email@gmail.com
+  crd_namespace: ''
+  crd_urls: https://raw.githubusercontent.com/buildpacks-community/kpack/refs/tags/v0.16.1/api/openapi-spec/swagger.json
+  versions: "'0.16.1'"
+  version_replacement_sed: refs/tags/v
+  dependencies: "cloudcoil.models.kubernetes"

--- a/models/kpack/pyproject.toml
+++ b/models/kpack/pyproject.toml
@@ -1,0 +1,18 @@
+transformations = [
+    { match = "^io\\.k8s\\.apimachinery\\..*\\.(.+)", replace = "apimachinery.\\g<1>", namespace = "cloudcoil"},
+    { match = "^io\\.k8s\\.apiextensions-apiserver\\.pkg\\.apis\\.apiextensions\\.(.+)$", replace = "apiextensions.\\g<1>", namespace = "cloudcoil.models.kubernetes"},
+    { match = "^io\\.k8s\\.api\\.(.+)$", replace = "\\g<1>", namespace = "cloudcoil.models.kubernetes"},
+    { match = "^io\\.k8s\\.kube-aggregator\\.pkg\\.apis\\.(.+)$", replace = "\\g<1>", namespace = "cloudcoil.models.kubernetes"},
+    { match = "^kpack\\.(.*)$", replace = "\\g<1>"},
+]
+
+aliases = [
+    {"from" = "builder", to = "builder_"},
+]
+updates = [
+    {match="^.*build\\.(.*)\\.(Image|Build|Buildpack|Builder|SourceResolver|ClusterStore|ClusterStack|ClusterBuildpack|ClusterBuilder)$",jsonpath="x-kubernetes-group-version-kind[0].kind", value="\\g<2>"},
+    {match="^.*build\\.(.*)\\.(Image|Build|Buildpack|Builder|SourceResolver|ClusterStore|ClusterStack|ClusterBuildpack|ClusterBuilder)$",jsonpath="x-kubernetes-group-version-kind[0].version", value="\\g<1>"},
+    {match="^.*build\\.(.*)\\.(Image|Build|Buildpack|Builder|SourceResolver|ClusterStore|ClusterStack|ClusterBuildpack|ClusterBuilder)$",jsonpath="x-kubernetes-group-version-kind[0].group", value="kpack.io"},
+    {match="^(.*build.*)\\.(Builder)$", jsonpath="title", value="\\g<1>.BuilderResource"},
+    {match="^(.*build.*)\\.(BuilderList)$", jsonpath="title", value="\\g<1>.BuilderResourceList"},
+]


### PR DESCRIPTION
This pull request includes several changes to improve the `cloudcoil` project, particularly focusing on the `kpack` model and its dependencies. The most important changes include updates to templates, configuration files, and documentation.

### Template and Configuration Updates:

* [`cloudcoil/codegen/templates/pydantic_v2/BaseModel.jinja2`](diffhunk://#diff-1ec40bf99182f1b718f59e8cc58139f928ed6abe7ef19337a1617e484eb780f2L155-R155): Improved handling of default values for optional fields by validating them against their type hints.
* [`cookiecutter/cookiecutter.json`](diffhunk://#diff-2c36d8b2788410001c86a72b99ebd493328cf62e5bb23a8ccbb0b8152c69314dR10): Added a new `dependencies` field to the configuration.
* [`cookiecutter/models-{{ cookiecutter.model_name }}/pyproject.toml`](diffhunk://#diff-93f23bcf656ccb40180196ebf075e75fb98a00d86eacdd459dbe490ef99d245eR18-R20): Dynamically included dependencies specified in the `cookiecutter.json` file.
* [`models/kpack/cookiecutter.yaml`](diffhunk://#diff-1c7d4a93ebbf59d6bc7452d9a9b1aebe96e37fff9a01fbdbb5fd02f7064d64a7R1-R9): Added default context including model name, author details, CRD URLs, versions, and dependencies.
* [`models/kpack/pyproject.toml`](diffhunk://#diff-3fcf51f98b4899dd66373616654b1a053e45368306ae802f9cdf630f539de1b0R1-R18): Added transformations, aliases, and updates for handling Kubernetes API conventions and kpack-specific naming.

### Documentation:

* [`models/kpack/README.md`](diffhunk://#diff-702b356b346bfd4facc1fd4f7cfda8e1ae809fe250e7e2e4c26306038448f829R1-R171): Added comprehensive instructions and examples for using kpack models, including installation steps, usage examples, and information about the fluent builder and context manager builder APIs.