### PR TITLE
Add initial support for subresources and status subresource

### DIFF
--- a/cloudcoil/_testing/clusters.py
+++ b/cloudcoil/_testing/clusters.py
@@ -43,7 +43,7 @@ class BaseCluster:
     def _download_binary(self, url: str, binary_path: Path) -> str:
         if not binary_path.exists():
             binary_lock = self._get_binary_lock_file(binary_path)
-            with FileLock(binary_lock):
+            with FileLock(str(binary_lock)):
                 if not binary_path.exists():  # Check again under lock
                     binary_path.parent.mkdir(parents=True, exist_ok=True)
                     response = httpx.get(url, follow_redirects=True)
@@ -80,7 +80,7 @@ class K3DCluster(BaseCluster):
         self.binary = self._download_binary(url, self.binary_path)
 
     def create_cluster(self) -> None:
-        with FileLock(self._lock_file):
+        with FileLock(str(self._lock_file)):
             try:
                 subprocess.run(
                     [self.binary, "cluster", "get", self.cluster_name],
@@ -110,7 +110,7 @@ class K3DCluster(BaseCluster):
         return kubeconfig_file.name
 
     def remove_cluster(self) -> None:
-        with FileLock(self._lock_file):
+        with FileLock(str(self._lock_file)):
             subprocess.run([self.binary, "cluster", "delete", self.cluster_name], check=True)
 
 
@@ -136,7 +136,7 @@ class KindCluster(BaseCluster):
         self._kubeconfig = tempfile.NamedTemporaryFile(delete=False).name
 
     def create_cluster(self) -> None:
-        with FileLock(self._lock_file):
+        with FileLock(str(self._lock_file)):
             clusters = (
                 subprocess.run(
                     [self.binary, "get", "clusters"],
@@ -174,7 +174,7 @@ class KindCluster(BaseCluster):
         return self._kubeconfig
 
     def remove_cluster(self) -> None:
-        with FileLock(self._lock_file):
+        with FileLock(str(self._lock_file)):
             subprocess.run(
                 [self.binary, "delete", "cluster", f"--name={self.cluster_name}"], check=True
             )

--- a/cloudcoil/resources.py
+++ b/cloudcoil/resources.py
@@ -141,29 +141,33 @@ class Resource(BaseResource):
         config = context.active_config
         return await config.client_for(self.__class__, sync=False).create(self, dry_run=dry_run)
 
-    def update(self, dry_run: bool = False) -> Self:
+    def update(self, dry_run: bool = False, with_status: bool = False) -> Self:
         config = context.active_config
-        return config.client_for(self.__class__, sync=True).update(self, dry_run=dry_run)
+        return config.client_for(self.__class__, sync=True).update(
+            self, dry_run=dry_run, with_status=with_status
+        )
 
-    async def async_update(self, dry_run: bool = False) -> Self:
+    async def async_update(self, dry_run: bool = False, with_status: bool = False) -> Self:
         config = context.active_config
-        return await config.client_for(self.__class__, sync=False).update(self, dry_run=dry_run)
+        return await config.client_for(self.__class__, sync=False).update(
+            self, dry_run=dry_run, with_status=with_status
+        )
 
-    def save(self, dry_run: bool = False) -> Self:
+    def save(self, dry_run: bool = False, with_status: bool = False) -> Self:
         try:
             self.fetch()
         except ResourceNotFound:
             return self.create(dry_run=dry_run)
         else:
-            return self.update(dry_run=dry_run)
+            return self.update(dry_run=dry_run, with_status=with_status)
 
-    async def async_save(self, dry_run: bool = False) -> Self:
+    async def async_save(self, dry_run: bool = False, with_status: bool = False) -> Self:
         try:
             await self.async_fetch()
         except ResourceNotFound:
             return await self.async_create(dry_run=dry_run)
         else:
-            return await self.async_update(dry_run=dry_run)
+            return await self.async_update(dry_run=dry_run, with_status=with_status)
 
     @classmethod
     def delete(

--- a/tests/test_async_e2e.py
+++ b/tests/test_async_e2e.py
@@ -200,3 +200,38 @@ async def test_async_watch_operations(test_config):
         assert any(
             event[0] == "MODIFIED" and event[1].status.phase == "Terminating" for event in events
         )
+
+
+@pytest.mark.configure_test_cluster(
+    cluster_name=f"test-cloudcoil-async-v{k8s_version}",
+    version=f"v{k8s_version}",
+    provider=cluster_provider,
+    remove=False,
+)
+async def test_async_status_operations(test_config):
+    with test_config:
+        ns = await k8s.core.v1.Namespace(metadata=ObjectMeta(generate_name="test-")).async_create()
+
+        # Create a Job
+        job = k8s.batch.v1.Job(
+            metadata=dict(name="test-status", namespace=ns.name),
+            spec={
+                "template": {
+                    "spec": {
+                        "containers": [
+                            {"name": "test", "image": "busybox", "command": ["sh", "-c", "sleep 1"]}
+                        ],
+                        "restartPolicy": "Never",
+                    }
+                }
+            },
+        )
+        created = await job.async_create()
+
+        # Test status update
+        now = "2024-01-01T00:00:00+00:00"
+        created.status.start_time = now
+        updated = await created.async_update(with_status=True)
+        assert updated.status.start_time.root.isoformat() == now
+        await job.async_remove()
+        await ns.async_remove()

--- a/tests/test_sync_e2e.py
+++ b/tests/test_sync_e2e.py
@@ -195,3 +195,38 @@ def test_watch_operations(test_config):
         assert any(
             event[0] == "MODIFIED" and event[1].status.phase == "Terminating" for event in events
         )
+
+
+@pytest.mark.configure_test_cluster(
+    cluster_name=f"test-cloudcoil-sync-v{k8s_version}",
+    version=f"v{k8s_version}",
+    provider=cluster_provider,
+    remove=False,
+)
+def test_status_operations(test_config):
+    with test_config:
+        ns = k8s.core.v1.Namespace(metadata=ObjectMeta(generate_name="test-")).create()
+
+        # Create a Job
+        job = k8s.batch.v1.Job(
+            metadata=dict(name="test-status", namespace=ns.name),
+            spec={
+                "template": {
+                    "spec": {
+                        "containers": [
+                            {"name": "test", "image": "busybox", "command": ["sh", "-c", "sleep 1"]}
+                        ],
+                        "restartPolicy": "Never",
+                    }
+                }
+            },
+        )
+        created = job.create()
+
+        # Test status update
+        now = "2024-01-01T00:00:00+00:00"
+        created.status.start_time = now
+        updated = created.update(with_status=True)
+        assert updated.status.start_time.root.isoformat() == now
+        job.remove()
+        ns.remove()


### PR DESCRIPTION
This pull request includes several changes to improve the handling of file locks and the management of subresources in the `cloudcoil` project. The most important changes include modifying the `FileLock` usage to convert paths to strings, adding support for subresources in the API client, and updating the resource update methods to handle status updates.

### Improvements to File Lock Handling:
* Modified `FileLock` usage to convert paths to strings in multiple methods within `cloudcoil/_testing/clusters.py`. [[1]](diffhunk://#diff-04543f63892ca6341522e3af330356cc860be99651ddf3225133409bd9a8809bL46-R46) [[2]](diffhunk://#diff-04543f63892ca6341522e3af330356cc860be99651ddf3225133409bd9a8809bL83-R83) [[3]](diffhunk://#diff-04543f63892ca6341522e3af330356cc860be99651ddf3225133409bd9a8809bL113-R113) [[4]](diffhunk://#diff-04543f63892ca6341522e3af330356cc860be99651ddf3225133409bd9a8809bL139-R139) [[5]](diffhunk://#diff-04543f63892ca6341522e3af330356cc860be99651ddf3225133409bd9a8809bL177-R177)

### Support for Subresources in API Client:
* Added `subresources` parameter to the `__init__` method in `cloudcoil/client/_api_client.py` and updated related methods to handle subresources. [[1]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066R41) [[2]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066R50) [[3]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066R133-R138) [[4]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066L157-R160) [[5]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066L169-R188) [[6]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066R422-R427) [[7]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066L429-R449) [[8]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066L441-R478)
* Updated `_process_api_discovery` and `_process_api_resources` methods in `cloudcoil/client/_config.py` to include subresources in the resource mapping. [[1]](diffhunk://#diff-0794500b70c79f233e6f3cb70a9dec87baf56a0626947b46653c915d034dd472R284-R286) [[2]](diffhunk://#diff-0794500b70c79f233e6f3cb70a9dec87baf56a0626947b46653c915d034dd472R296) [[3]](diffhunk://#diff-0794500b70c79f233e6f3cb70a9dec87baf56a0626947b46653c915d034dd472R310-R319) [[4]](diffhunk://#diff-0794500b70c79f233e6f3cb70a9dec87baf56a0626947b46653c915d034dd472R343) [[5]](diffhunk://#diff-0794500b70c79f233e6f3cb70a9dec87baf56a0626947b46653c915d034dd472R352)

### Resource Update Methods:
* Enhanced resource update methods in `cloudcoil/resources.py` to handle status updates with the `with_status` parameter.

### New Tests for Status Operations:
* Added new async and sync tests for status operations in `tests/test_async_e2e.py` and `tests/test_sync_e2e.py`. [[1]](diffhunk://#diff-638e7cea7dab7f3064d33a91b30db8e26f5407fc8cb91d786fa2d951c992ffd9R203-R237) [[2]](diffhunk://#diff-8b4f04102e345e42b9d3691c8f5a193f3d6f28f0f2b3af510711014fb4b98314R198-R232)


Fixes #91 