### PR TITLE
Fix status updates to use PUT instead of PATCH

### DIFF
--- a/cloudcoil/errors.py
+++ b/cloudcoil/errors.py
@@ -6,7 +6,7 @@ class ResourceNotFound(APIError):
     pass
 
 
-class ResourceAlreadyExists(APIError):
+class ResourceConflict(APIError):
     pass
 
 

--- a/cloudcoil/resources.py
+++ b/cloudcoil/resources.py
@@ -141,33 +141,39 @@ class Resource(BaseResource):
         config = context.active_config
         return await config.client_for(self.__class__, sync=False).create(self, dry_run=dry_run)
 
-    def update(self, dry_run: bool = False, with_status: bool = False) -> Self:
+    def update(self, dry_run: bool = False) -> Self:
         config = context.active_config
-        return config.client_for(self.__class__, sync=True).update(
-            self, dry_run=dry_run, with_status=with_status
+        return config.client_for(self.__class__, sync=True).update(self, dry_run=dry_run)
+
+    async def async_update(self, dry_run: bool = False) -> Self:
+        config = context.active_config
+        return await config.client_for(self.__class__, sync=False).update(self, dry_run=dry_run)
+
+    def update_status(self, dry_run: bool = False) -> Self:
+        config = context.active_config
+        return config.client_for(self.__class__, sync=True).update_status(self, dry_run=dry_run)
+
+    async def async_update_status(self, dry_run: bool = False) -> Self:
+        config = context.active_config
+        return await config.client_for(self.__class__, sync=False).update_status(
+            self, dry_run=dry_run
         )
 
-    async def async_update(self, dry_run: bool = False, with_status: bool = False) -> Self:
-        config = context.active_config
-        return await config.client_for(self.__class__, sync=False).update(
-            self, dry_run=dry_run, with_status=with_status
-        )
-
-    def save(self, dry_run: bool = False, with_status: bool = False) -> Self:
+    def save(self, dry_run: bool = False) -> Self:
         try:
             self.fetch()
         except ResourceNotFound:
             return self.create(dry_run=dry_run)
         else:
-            return self.update(dry_run=dry_run, with_status=with_status)
+            return self.update(dry_run=dry_run)
 
-    async def async_save(self, dry_run: bool = False, with_status: bool = False) -> Self:
+    async def async_save(self, dry_run: bool = False) -> Self:
         try:
             await self.async_fetch()
         except ResourceNotFound:
             return await self.async_create(dry_run=dry_run)
         else:
-            return await self.async_update(dry_run=dry_run, with_status=with_status)
+            return await self.async_update(dry_run=dry_run)
 
     @classmethod
     def delete(
@@ -637,7 +643,7 @@ class Unstructured(Resource):
     def __setitem__(self, key: str, value: Any) -> None:
         self._data[key] = value
         # Also update the model data
-        object.__setattr__(self, key, value)
+        BaseModel.__setattr__(self, key, value)
 
     def __contains__(self, key: str) -> bool:
         return key in self._data


### PR DESCRIPTION
This pull request includes significant updates to the `cloudcoil/client/_api_client.py` file and test files to improve the handling of custom resource definitions (CRDs) and their status updates. The most important changes include switching from PATCH to PUT requests for status updates, refactoring test cases for better structure and clarity, and ensuring proper cleanup after tests.

### Updates to status handling:
* [`cloudcoil/client/_api_client.py`](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066L189-L193): Changed the method for updating status from PATCH to PUT, and included additional metadata in the request payload. [[1]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066L189-L193) [[2]](diffhunk://#diff-003c287eabfb30f1d5ac7eab59dcc0603f8d6e6c45e7554828113dfffcdb8066L497-L501)

### Refactoring test cases:
* [`tests/test_async_e2e.py`](diffhunk://#diff-638e7cea7dab7f3064d33a91b30db8e26f5407fc8cb91d786fa2d951c992ffd9L290-R292): Refactored the `test_async_crd_scale_operations` test to include namespace creation, CRD establishment checks, custom resource creation, status updates, scaling, and cleanup. [[1]](diffhunk://#diff-638e7cea7dab7f3064d33a91b30db8e26f5407fc8cb91d786fa2d951c992ffd9L290-R292) [[2]](diffhunk://#diff-638e7cea7dab7f3064d33a91b30db8e26f5407fc8cb91d786fa2d951c992ffd9L300-R352)
* [`tests/test_sync_e2e.py`](diffhunk://#diff-8b4f04102e345e42b9d3691c8f5a193f3d6f28f0f2b3af510711014fb4b98314L285-R345): Refactored the `test_crd_scale_operations` test to follow a similar structure as the async test, including namespace creation, CRD establishment checks, custom resource creation, status updates, scaling, and cleanup.