### PR TITLE
Respect `insecure-skip-tls-verify` on kubeconfig

### DIFF
--- a/cloudcoil/client/_config.py
+++ b/cloudcoil/client/_config.py
@@ -194,7 +194,7 @@ class Config:
             ctx = ssl.create_default_context(cafile=self.cafile)
             if self.certfile and self.keyfile:
                 ctx.load_cert_chain(certfile=self.certfile, keyfile=self.keyfile)
-        
+
         headers = {
             # Add a custom User-Agent to identify the client
             # similar to kubectl

--- a/cloudcoil/client/_config.py
+++ b/cloudcoil/client/_config.py
@@ -103,7 +103,7 @@ class Config:
         self.certfile = None
         self.keyfile = None
         self.token = None
-        skip_tls = False
+        insecure_skip_tls_verify = False
         tempdir = tempfile.TemporaryDirectory()
         kubeconfig = kubeconfig or os.environ.get("KUBECONFIG")
         if kubeconfig:
@@ -155,7 +155,7 @@ class Config:
                 self.cafile = cafile
 
             if "insecure-skip-tls-verify" in cluster_data:
-                skip_tls = cluster_data["insecure-skip-tls-verify"]
+                insecure_skip_tls_verify = cluster_data["insecure-skip-tls-verify"]
 
             if "namespace" in context_data:
                 self.namespace = context_data["namespace"]
@@ -190,7 +190,7 @@ class Config:
         self.keyfile = keyfile or self.keyfile
 
         ctx: ssl.SSLContext | bool = False
-        if not skip_tls:
+        if not insecure_skip_tls_verify:
             ctx = ssl.create_default_context(cafile=self.cafile)
             if self.certfile and self.keyfile:
                 ctx.load_cert_chain(certfile=self.certfile, keyfile=self.keyfile)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ import json
 import os
 from unittest.mock import patch
 
+import ssl
 import pytest
 import yaml
 from httpx import Response
@@ -42,6 +43,7 @@ from cloudcoil.client._config import (
                 "server": "https://test-server",
                 "namespace": "test-ns",
                 "token": "test-token",
+                "ssl_verify_mode": ssl.CERT_REQUIRED
             },
         ),
         # Test case 2: Kubeconfig with certificate data
@@ -73,7 +75,38 @@ from cloudcoil.client._config import (
                     }
                 ],
             },
-            {"server": "https://test-server", "namespace": "default"},
+            {"server": "https://test-server", "namespace": "default", "ssl_verify_mode": ssl.CERT_REQUIRED},
+        ),
+        # Test case 3: Kubeconfig with insecure-skip-tls
+        (
+            {
+                "current-context": "test-context",
+                "contexts": [
+                    {
+                        "name": "test-context",
+                        "context": {"cluster": "test-cluster", "user": "test-user"},
+                    }
+                ],
+                "clusters": [
+                    {
+                        "name": "test-cluster",
+                        "cluster": {
+                            "server": "https://test-server",
+                            "insecure-skip-tls-verify": True
+                        },
+                    }
+                ],
+                "users": [
+                    {
+                        "name": "test-user",
+                        "user": {
+                            "client-certificate-data": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJrakNDQVRlZ0F3SUJBZ0lJV2hxakpvUFR6Qkl3Q2dZSUtvWkl6ajBFQXdJd0l6RWhNQjhHQTFVRUF3d1kKYXpOekxXTnNhV1Z1ZEMxallVQXhOek0xTkRBM01qY3pNQjRYRFRJME1USXlPREUzTXpRek0xb1hEVEkxTVRJeQpPREUzTXpRek0xb3dNREVYTUJVR0ExVUVDaE1PYzNsemRHVnRPbTFoYzNSbGNuTXhGVEFUQmdOVkJBTVRESE41CmMzUmxiVHBoWkcxcGJqQlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VIQTBJQUJBaXVzZ3ExcG9QYkM3S3AKbVU4UmRKZDU1K3BkY1dVZkF1Z3h1S29ucEMxVmpERHRXaEpEWkxycktsQWk4ZkxlMkJRV29aOEVXSDNkTmxtVwpmb093K2RXalNEQkdNQTRHQTFVZER3RUIvd1FFQXdJRm9EQVRCZ05WSFNVRUREQUtCZ2dyQmdFRkJRY0RBakFmCkJnTlZIU01FR0RBV2dCVHZTQlQrVk83b2s5MkJ5T2pkRnRacmo5a21oVEFLQmdncWhrak9QUVFEQWdOSkFEQkcKQWlFQXZVcGdYU3d2akpkaUdaUEJJVHhnTmNZdHA2VDVJbjN2eDUzRmZXeGVlcjRDSVFDWDhveWZwVGl5aTljSQplNGRlUTdSR1ZuaTErNDhabXBOL1M5QXRNd2pIV0E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLQpNSUlCZHpDQ0FSMmdBd0lCQWdJQkFEQUtCZ2dxaGtqT1BRUURBakFqTVNFd0h3WURWUVFEREJock0zTXRZMnhwClpXNTBMV05oUURFM016VTBNRGN5TnpNd0hoY05NalF4TWpJNE1UY3pORE16V2hjTk16UXhNakkyTVRjek5ETXoKV2pBak1TRXdId1lEVlFRRERCaHJNM010WTJ4cFpXNTBMV05oUURFM016VTBNRGN5TnpNd1dUQVRCZ2NxaGtqTwpQUUlCQmdncWhrak9QUU1CQndOQ0FBU2hrNHpxa2dXNU96NnMzNWpoa0JzenBtazRwS0ROa2FKWGpaWTlIakcvCkR3N0VwcXFLT0prTEQvbEZjUk9nY1czdDBZajgxM3pOTmpXcmdUbTN4YjY3bzBJd1FEQU9CZ05WSFE4QkFmOEUKQkFNQ0FxUXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVU3MGdVL2xUdTZKUGRnY2pvM1JiVwphNC9aSm9Vd0NnWUlLb1pJemowRUF3SURTQUF3UlFJZ2VvTWViOFcrRzFpTjZDcW5tQm5QOGg4TDYzNWsrTXhFCnJzNnBYYUN1SEFJQ0lRRERJVWRlR1BjTUQ2eW1JVE1xbnBuUVkxMFp3cGkzQWxZUVFJcDNjb05iM2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==",  # base64 encoded "clientcert"
+                            "client-key-data": "LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSU8wN1hGT0lmTVFyS3Z6Skp4OEkrbnpCQXdnZmpuVGdWZ3o4L2JiRi9Sc1hvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFQ0s2eUNyV21nOXNMc3FtWlR4RjBsM25uNmwxeFpSOEM2REc0cWlla0xWV01NTzFhRWtOawp1dXNxVUNMeDh0N1lGQmFobndSWWZkMDJXWlorZzdENTFRPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=",  # base64 encoded "clientkey"
+                        },
+                    }
+                ],
+            },
+            {"server": "https://test-server", "namespace": "default", "ssl_verify_mode": ssl.CERT_NONE},
         ),
     ],
 )
@@ -87,6 +120,9 @@ def test_kubeconfig_initialization(kubeconfig_content, expected, tmp_path):
         assert client.namespace == expected["namespace"]
         if "token" in expected:
             assert client.token == expected["token"]
+
+        # Context information like `verify=<ctx or bool>` passed to the httpx.Client is only reflected on the transport pool 
+        assert client.client._transport._pool._ssl_context.verify_mode == expected["ssl_verify_mode"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,9 +2,9 @@
 
 import json
 import os
+import ssl
 from unittest.mock import patch
 
-import ssl
 import pytest
 import yaml
 from httpx import Response
@@ -43,7 +43,7 @@ from cloudcoil.client._config import (
                 "server": "https://test-server",
                 "namespace": "test-ns",
                 "token": "test-token",
-                "ssl_verify_mode": ssl.CERT_REQUIRED
+                "ssl_verify_mode": ssl.CERT_REQUIRED,
             },
         ),
         # Test case 2: Kubeconfig with certificate data
@@ -75,7 +75,11 @@ from cloudcoil.client._config import (
                     }
                 ],
             },
-            {"server": "https://test-server", "namespace": "default", "ssl_verify_mode": ssl.CERT_REQUIRED},
+            {
+                "server": "https://test-server",
+                "namespace": "default",
+                "ssl_verify_mode": ssl.CERT_REQUIRED,
+            },
         ),
         # Test case 3: Kubeconfig with insecure-skip-tls
         (
@@ -92,7 +96,7 @@ from cloudcoil.client._config import (
                         "name": "test-cluster",
                         "cluster": {
                             "server": "https://test-server",
-                            "insecure-skip-tls-verify": True
+                            "insecure-skip-tls-verify": True,
                         },
                     }
                 ],
@@ -106,7 +110,11 @@ from cloudcoil.client._config import (
                     }
                 ],
             },
-            {"server": "https://test-server", "namespace": "default", "ssl_verify_mode": ssl.CERT_NONE},
+            {
+                "server": "https://test-server",
+                "namespace": "default",
+                "ssl_verify_mode": ssl.CERT_NONE,
+            },
         ),
     ],
 )
@@ -121,8 +129,10 @@ def test_kubeconfig_initialization(kubeconfig_content, expected, tmp_path):
         if "token" in expected:
             assert client.token == expected["token"]
 
-        # Context information like `verify=<ctx or bool>` passed to the httpx.Client is only reflected on the transport pool 
-        assert client.client._transport._pool._ssl_context.verify_mode == expected["ssl_verify_mode"]
+        # Context information like `verify=<ctx or bool>` passed to the httpx.Client is only reflected on the transport pool
+        assert (
+            client.client._transport._pool._ssl_context.verify_mode == expected["ssl_verify_mode"]
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [X] Tests added
- [ ] Documentation/examples added
- [X] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, `cloudcoil` expect certificate data to be present on the kubeconfig and respects it. The problem is not always will users have that, although not best practice sometimes users will just want to skip the api-server certificate verification.
This is done through setting `insecure-skip-tls-verify: True` on the cluster data section.

Currently, `cloudcoil` does not check for such option and will carry on with the information available which means using the default `SSLContext` and using whatever CAs are available in the machine. If the machine is not set up to be able to verify the api-server certificate the connection will fail with an SSL error.


This PR adds a check for the value of `insecure-skip-tls-verify` and if `True` it will skip setting a `SSLContext` and will set `httpx.Client` to not check the server certificate
