### PR TITLE
Add badges to generated readmes

### DIFF
--- a/cookiecutter/models-{{ cookiecutter.model_name }}/README.md
+++ b/cookiecutter/models-{{ cookiecutter.model_name }}/README.md
@@ -1,3 +1,8 @@
 # cloudcoil-models-{{cookiecutter.model_name}}
 
 Versioned {{cookiecutter.model_name}} models for cloudcoil.
+
+[![PyPI](https://img.shields.io/pypi/v/cloudcoil.models.{{ cookiecutter.module_name }}.svg)](https://pypi.python.org/pypi/cloudcoil.models.{{ cookiecutter.module_name }})
+[![Downloads](https://static.pepy.tech/badge/cloudcoil.models.{{ cookiecutter.module_name }})](https://pepy.tech/project/cloudcoil.models.{{ cookiecutter.module_name }})
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/license/apache-2-0/)
+[![CI](https://github.com/cloudcoil/models-{{ cookiecutter.model_name }}/actions/workflows/ci.yml/badge.svg)](https://github.com/cloudcoil/models-{{ cookiecutter.model_name }}/actions/workflows/ci.yml)


### PR DESCRIPTION
This pull request adds badges to the `README.md` file for the `cookiecutter/models-{{ cookiecutter.model_name }}` project. These badges provide useful information about the package version, download statistics, license, and continuous integration status.

Most important changes:

* [`cookiecutter/models-{{ cookiecutter.model_name }}/README.md`](diffhunk://#diff-9183367ec938987c3bd4bb58e59d683795cf49aa4026977b2d8e624c60bdd6e0R4-R8): Added badges for PyPI version, download statistics, Apache-2.0 license, and CI status.