### PR TITLE
Update _config.py, fix ApiClient authing SSLContext when skip_verify=…

### DIFF
--- a/cloudcoil/client/_config.py
+++ b/cloudcoil/client/_config.py
@@ -262,8 +262,7 @@ class Config:
             ctx.load_cert_chain(certfile=self.certfile, keyfile=self.keyfile)
 
         if self.skip_verify:
-            logger.warning("Creating insecure SSL context (verify=False)")
-            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            logger.warning("Using insecure SSL context (verify=False)")
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
 


### PR DESCRIPTION
This PR adds/changes/fixes a BUG of APIClient：when skip_verify in KUBECONFIG is True, SSLContext is replaced but certfile & keyfile are not loaded, causing 401 Error.

When skip_verify is True, method `load_cert_chain` still needs to be called. Alternatively, just keep the previous SSLContext object.
