### PR TITLE
Fix ValueError when `version_data["minor"]` contains `+`

### DIFF
--- a/cloudcoil/client/_config.py
+++ b/cloudcoil/client/_config.py
@@ -289,7 +289,7 @@ class Config:
             logger.error("Failed to get Kubernetes version: %s", version_response.text)
             raise ValueError(f"Failed to get version: {version_response.text}")
         version_data = version_response.json()
-        major, minor = int(version_data["major"]), int(version_data["minor"])
+        major, minor = int(version_data["major"]), int(version_data["minor"].rstrip('+'))
         logger.debug("Connected to Kubernetes %s.%s", major, minor)
 
         if major > 1 or (major == 1 and minor >= 30):

--- a/cloudcoil/client/_config.py
+++ b/cloudcoil/client/_config.py
@@ -289,8 +289,8 @@ class Config:
             logger.error("Failed to get Kubernetes version: %s", version_response.text)
             raise ValueError(f"Failed to get version: {version_response.text}")
         version_data = version_response.json()
-        major = int(version_data["major"])
-        minor = int(version_data["minor"].rstrip('+'))
+        major = int("".join(filter(str.isdigit, version_data["major"])))
+        minor = int("".join(filter(str.isdigit, version_data["minor"])))
         logger.debug("Connected to Kubernetes %s.%s", major, minor)
 
         if major > 1 or (major == 1 and minor >= 30):

--- a/cloudcoil/client/_config.py
+++ b/cloudcoil/client/_config.py
@@ -289,7 +289,8 @@ class Config:
             logger.error("Failed to get Kubernetes version: %s", version_response.text)
             raise ValueError(f"Failed to get version: {version_response.text}")
         version_data = version_response.json()
-        major, minor = int(version_data["major"]), int(version_data["minor"].rstrip('+'))
+        major = int(version_data["major"])
+        minor = int(version_data["minor"].rstrip('+'))
         logger.debug("Connected to Kubernetes %s.%s", major, minor)
 
         if major > 1 or (major == 1 and minor >= 30):


### PR DESCRIPTION
When the  `minor`   field in the Kubernetes API Server's   `/version`   response contains a   `+`  , the current code throws a   `ValueError`.

For example, the response body might look like this:

Response Body: 

```python
{
  "major": "1",
  "minor": "26+",
  "gitVersion": "v1.26.1-tke.3",
  "gitCommit": "38d7740632d901ebf9040053ca5ece34d1f809be",
  "gitTreeState": "clean",
  "buildDate": "2023-11-30T13:06:08Z",
  "goVersion": "go1.19.9",
  "compiler": "gc",
  "platform": "linux/amd64"
}
```

Log:
```python
File "/usr/local/lib/python3.11/site-packages/cloudcoil/client/_config.py", line 292, in _create_rest_mapper                                                                                                                  major, minor = int(version_data["major"]), int(version_data["minor"])                                                                                                                                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '26+'
```

**Pull Request Checklist**
- [ ] Fixes #<!--issue number goes here-->
- [ ] Tests added
- [ ] Documentation/examples added
- [ ] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, ...

This PR adds/changes/fixes...
