### PR TITLE
fix auth failure caused by `httpx.AsyncClient` missing headers

### DIFF
--- a/cloudcoil/client/_config.py
+++ b/cloudcoil/client/_config.py
@@ -278,7 +278,7 @@ class Config:
             verify=ctx, auth=self.auth or None, base_url=self.server, headers=headers
         )
         self.async_client = httpx.AsyncClient(
-            verify=ctx, auth=self.auth or None, base_url=self.server
+            verify=ctx, auth=self.auth or None, base_url=self.server, headers=headers
         )
         self._rest_mapping: dict[GVK, Any] = {}
 


### PR DESCRIPTION
This PR fixes auth failure caused by missing headers in AsyncClient. 
