### PR TITLE
Move model_valdiate after checking error

### DIFF
--- a/cloudcoil/client/_api_client.py
+++ b/cloudcoil/client/_api_client.py
@@ -426,7 +426,6 @@ class APIClient(_BaseAPIClient[T]):
                             continue
                         event = json.loads(line)
                         type_ = event["type"]
-                        obj = self.kind.model_validate(event["object"])
 
                         if type_ == "ERROR":
                             if "status" in event["object"]:
@@ -444,6 +443,7 @@ class APIClient(_BaseAPIClient[T]):
                             logger.error("Watch error event received: %s", event)
                             raise WatchError(f"Watch error: {event}")
 
+                        obj = self.kind.model_validate(event["object"])
                         if obj.metadata and obj.metadata.resource_version:
                             curr_resource_version = obj.metadata.resource_version
                         yield type_, obj
@@ -855,7 +855,6 @@ class AsyncAPIClient(_BaseAPIClient[T]):
                             continue
                         event = json.loads(line)
                         type_ = event["type"]
-                        obj = self.kind.model_validate(event["object"])
 
                         if type_ == "ERROR":
                             if "status" in event["object"]:
@@ -873,6 +872,7 @@ class AsyncAPIClient(_BaseAPIClient[T]):
                             logger.error("Watch error event received: %s", event)
                             raise WatchError(f"Watch error: {event}")
 
+                        obj = self.kind.model_validate(event["object"])
                         if obj.metadata and obj.metadata.resource_version:
                             curr_resource_version = obj.metadata.resource_version
                         yield type_, obj


### PR DESCRIPTION
**Pull Request Checklist**
- [x] Fixes #111 
- [ ] Tests added
- [ ] Documentation/examples added
- [x] [Good commit messages](https://cbea.ms/git-commit/) and/or PR title

**Description of PR**
Currently, cloudcoil parses object in event before handling errors which doesn't require typed object. So it would raise error when type=ERROR and object is v1.Status.

This PR changes to parse object in events after checking errors.
