### PR TITLE
Fix naming inconsistencies in informer/caching API

### DIFF
--- a/cloudcoil/caching/_cache.py
+++ b/cloudcoil/caching/_cache.py
@@ -58,14 +58,14 @@ class Cache(CacheConfig):
             self._started = False
             logger.debug("Cache stopped")
 
-    async def async_wait_for_cache_sync(self, timeout: Optional[float] = None) -> bool:
-        """Wait for cache to sync asynchronously.
+    async def async_wait(self, timeout: Optional[float] = None) -> bool:
+        """Wait for cache to be ready asynchronously.
 
         Args:
             timeout: Maximum time to wait (uses sync_timeout if not provided)
 
         Returns:
-            True if synced, False if timeout
+            True if ready, False if timeout
         """
         if not self.enabled or not self._factory:
             return True
@@ -87,14 +87,14 @@ class Cache(CacheConfig):
             self._factory.stop()
             self._started = False
 
-    def wait_for_cache_sync(self, timeout: Optional[float] = None) -> bool:
-        """Wait for cache to sync synchronously.
+    def wait(self, timeout: Optional[float] = None) -> bool:
+        """Wait for cache to be ready synchronously.
 
         Args:
             timeout: Maximum time to wait (uses sync_timeout if not provided)
 
         Returns:
-            True if synced, False if timeout
+            True if ready, False if timeout
         """
         if not self.enabled or not self._factory:
             return True

--- a/cloudcoil/caching/_cache.py
+++ b/cloudcoil/caching/_cache.py
@@ -87,7 +87,7 @@ class Cache(CacheConfig):
             self._factory.stop()
             self._started = False
 
-    def sync_wait_for_sync(self, timeout: Optional[float] = None) -> bool:
+    def wait_for_cache_sync(self, timeout: Optional[float] = None) -> bool:
         """Wait for cache to sync synchronously.
 
         Args:

--- a/cloudcoil/caching/_cache.py
+++ b/cloudcoil/caching/_cache.py
@@ -58,7 +58,7 @@ class Cache(CacheConfig):
             self._started = False
             logger.debug("Cache stopped")
 
-    async def async_wait_for_sync(self, timeout: Optional[float] = None) -> bool:
+    async def async_wait_for_cache_sync(self, timeout: Optional[float] = None) -> bool:
         """Wait for cache to sync asynchronously.
 
         Args:

--- a/cloudcoil/caching/_informer.py
+++ b/cloudcoil/caching/_informer.py
@@ -301,7 +301,7 @@ class AsyncInformer(Generic[T]):
 
     async def _handle_initial_items(self, items: List[T], resource_version: str) -> None:
         """Handle initial list of items."""
-        await self._store.replace(items)
+        await self._store.async_replace(items)
         self._sync_event.set()
         logger.info(
             "Initial sync complete for %s: %d items", self._client.kind.__name__, len(items)
@@ -323,19 +323,19 @@ class AsyncInformer(Generic[T]):
 
     async def _handle_add(self, obj: T) -> None:
         """Handle resource add."""
-        await self._store.add(obj)
+        await self._store.async_add(obj)
         await self._dispatcher.dispatch_add(obj)
 
     async def _handle_update(self, obj: T) -> None:
         """Handle resource update."""
         key = self._get_key(obj)
         old_obj = self._store.get(key) if key else None
-        await self._store.add(obj)  # add acts as update
+        await self._store.async_add(obj)  # add acts as update
         await self._dispatcher.dispatch_update(old_obj, obj)
 
     async def _handle_delete(self, obj: T) -> None:
         """Handle resource delete."""
-        await self._store.delete(obj)
+        await self._store.async_delete(obj)
         await self._dispatcher.dispatch_delete(obj)
 
     def _get_key(self, obj: T) -> Optional[str]:
@@ -618,7 +618,7 @@ class SyncInformer(Generic[T]):
 
     def _handle_initial_items(self, items: List[T], resource_version: str) -> None:
         """Handle initial list of items."""
-        self._store.sync_replace(items)  # Use sync version
+        self._store.replace(items)  # Use sync version
         self._sync_event.set()
         logger.info(
             "Initial sync complete for %s: %d items", self._client.kind.__name__, len(items)
@@ -639,19 +639,19 @@ class SyncInformer(Generic[T]):
 
     def _handle_add(self, obj: T) -> None:
         """Handle resource add."""
-        self._store.sync_add(obj)
+        self._store.add(obj)
         self._dispatcher.dispatch_add(obj)
 
     def _handle_update(self, obj: T) -> None:
         """Handle resource update."""
         key = self._get_key(obj)
         old_obj = self._store.get(key) if key else None
-        self._store.sync_add(obj)  # add works as update too
+        self._store.add(obj)  # add works as update too
         self._dispatcher.dispatch_update(old_obj, obj)
 
     def _handle_delete(self, obj: T) -> None:
         """Handle resource delete."""
-        self._store.sync_delete(obj)
+        self._store.delete(obj)
         self._dispatcher.dispatch_delete(obj)
 
     def _get_key(self, obj: T) -> Optional[str]:

--- a/cloudcoil/caching/_store.py
+++ b/cloudcoil/caching/_store.py
@@ -126,7 +126,7 @@ class ConcurrentStore(Generic[T]):
             raise KeyError(f"Index {index_name} not found")
         return list(self._indices[index_name].keys())
 
-    async def add(self, obj: T) -> None:
+    async def async_add(self, obj: T) -> None:
         """Add or update an object in the store (async-safe).
 
         Args:
@@ -135,7 +135,7 @@ class ConcurrentStore(Generic[T]):
         async with self._async_lock:
             self._add_internal(obj)
 
-    def sync_add(self, obj: T) -> None:
+    def add(self, obj: T) -> None:
         """Add or update an object in the store (thread-safe for sync wrapper).
 
         Args:
@@ -233,7 +233,7 @@ class ConcurrentStore(Generic[T]):
         """
         return list(self._items.keys())
 
-    async def delete(self, obj: T) -> None:
+    async def async_delete(self, obj: T) -> None:
         """Delete an object from the store (async-safe).
 
         Args:
@@ -244,7 +244,7 @@ class ConcurrentStore(Generic[T]):
             if key:
                 self._delete_internal(key)
 
-    def sync_delete(self, obj: T) -> None:
+    def delete(self, obj: T) -> None:
         """Delete an object from the store (thread-safe for sync wrapper).
 
         Args:
@@ -262,7 +262,7 @@ class ConcurrentStore(Generic[T]):
             del self._items[key]
             self._update_indices(key, obj, None)
 
-    async def replace(self, items: List[T]) -> None:
+    async def async_replace(self, items: List[T]) -> None:
         """Replace all items in the store (async-safe).
 
         Args:
@@ -271,7 +271,7 @@ class ConcurrentStore(Generic[T]):
         async with self._async_lock:
             self._replace_internal(items)
 
-    def sync_replace(self, items: List[T]) -> None:
+    def replace(self, items: List[T]) -> None:
         """Replace all items in the store (thread-safe for sync wrapper).
 
         Args:

--- a/cloudcoil/client/_config.py
+++ b/cloudcoil/client/_config.py
@@ -534,7 +534,7 @@ class Config:
             # Start cache synchronously
             self.cache.start()
             if self.cache.wait_for_sync:
-                if not self.cache.sync_wait_for_sync():
+                if not self.cache.wait_for_cache_sync():
                     if self.cache.mode == "strict":
                         from cloudcoil.errors import APIError
 

--- a/cloudcoil/client/_config.py
+++ b/cloudcoil/client/_config.py
@@ -534,7 +534,7 @@ class Config:
             # Start cache synchronously
             self.cache.start()
             if self.cache.wait_for_sync:
-                if not self.cache.wait_for_cache_sync():
+                if not self.cache.wait():
                     if self.cache.mode == "strict":
                         from cloudcoil.errors import APIError
 
@@ -555,7 +555,7 @@ class Config:
         if self.cache.enabled:
             await self.cache.async_start()
             if self.cache.wait_for_sync:
-                if not await self.cache.async_wait_for_cache_sync():
+                if not await self.cache.async_wait():
                     if self.cache.mode == "strict":
                         from cloudcoil.errors import APIError
 

--- a/cloudcoil/client/_config.py
+++ b/cloudcoil/client/_config.py
@@ -555,7 +555,7 @@ class Config:
         if self.cache.enabled:
             await self.cache.async_start()
             if self.cache.wait_for_sync:
-                if not await self.cache.async_wait_for_sync():
+                if not await self.cache.async_wait_for_cache_sync():
                     if self.cache.mode == "strict":
                         from cloudcoil.errors import APIError
 

--- a/tests/test_informers.py
+++ b/tests/test_informers.py
@@ -88,7 +88,7 @@ def test_sync_cache_basic_functionality(test_config):
         ns = k8s.core.v1.Namespace(metadata=ObjectMeta(generate_name="test-cache-")).create()
 
         # Wait for cache to sync
-        assert config.cache.sync_wait_for_sync(timeout=30.0)
+        assert config.cache.wait_for_cache_sync(timeout=30.0)
         assert config.cache.ready()
 
         # Get informer for ConfigMaps
@@ -632,7 +632,7 @@ def test_sync_informer_event_handlers(test_config):
         informer.on_delete(handle_delete)
 
         # Wait for sync
-        config.cache.sync_wait_for_sync(timeout=30.0)
+        config.cache.wait_for_cache_sync(timeout=30.0)
 
         # Create a ConfigMap
         cm = k8s.core.v1.ConfigMap(

--- a/tests/test_informers.py
+++ b/tests/test_informers.py
@@ -34,7 +34,7 @@ async def test_async_cache_basic_functionality(test_config):
         ).async_create()
 
         # Wait for cache to sync
-        assert await config.cache.async_wait_for_sync(timeout=30.0)
+        assert await config.cache.async_wait_for_cache_sync(timeout=30.0)
         assert config.cache.ready()
 
         # Test cache status
@@ -164,7 +164,7 @@ async def test_async_informer_event_handlers(test_config):
         informer.on_delete(handle_delete)
 
         # Wait for sync
-        await config.cache.async_wait_for_sync(timeout=30.0)
+        await config.cache.async_wait_for_cache_sync(timeout=30.0)
 
         # Create a ConfigMap
         cm = await k8s.core.v1.ConfigMap(
@@ -231,7 +231,7 @@ async def test_async_informer_filtering(test_config):
 
     async with config:
         # Wait for cache to sync
-        await config.cache.async_wait_for_sync(timeout=30.0)
+        await config.cache.async_wait_for_cache_sync(timeout=30.0)
 
         # Get informer
         informer = config.cache.get_informer(k8s.core.v1.ConfigMap)
@@ -294,7 +294,7 @@ async def test_async_informer_custom_indexing(test_config):
         informer.add_index("by_data_key", index_by_data_key)
 
         # Wait for sync
-        await config.cache.async_wait_for_sync(timeout=30.0)
+        await config.cache.async_wait_for_cache_sync(timeout=30.0)
 
         # Create ConfigMaps with different data keys
         cm1 = await k8s.core.v1.ConfigMap(
@@ -349,7 +349,7 @@ async def test_async_cache_modes(test_config):
         ).async_create()
 
         # In strict mode, operations should use cache only after sync
-        await strict_config.cache.async_wait_for_sync(timeout=30.0)
+        await strict_config.cache.async_wait_for_cache_sync(timeout=30.0)
 
         # Create a ConfigMap through API (not cache)
         cm = await k8s.core.v1.ConfigMap(
@@ -376,7 +376,7 @@ async def test_async_cache_modes(test_config):
         ).async_create()
 
         # Wait for cache sync
-        await fallback_config.cache.async_wait_for_sync(timeout=30.0)
+        await fallback_config.cache.async_wait_for_cache_sync(timeout=30.0)
 
         # Create a ConfigMap
         cm = await k8s.core.v1.ConfigMap(
@@ -406,7 +406,7 @@ async def test_async_cache_context_managers(test_config):
     config = test_config.with_cache(cache_config)
 
     async with config:
-        await config.cache.async_wait_for_sync(timeout=30.0)
+        await config.cache.async_wait_for_cache_sync(timeout=30.0)
 
         # Test pause context manager
         assert config.cache.enabled
@@ -467,7 +467,7 @@ async def test_async_cache_performance_comparison(test_config):
     # Test performance with cache
     async with cached_config:
         # Wait for cache to sync
-        await cached_config.cache.async_wait_for_sync(timeout=30.0)
+        await cached_config.cache.async_wait_for_cache_sync(timeout=30.0)
 
         informer = cached_config.cache.get_informer(k8s.core.v1.ConfigMap)
         assert informer is not None
@@ -510,7 +510,7 @@ async def test_async_multiple_resource_types(test_config):
         ).async_create()
 
         # Wait for cache to sync
-        await config.cache.async_wait_for_sync(timeout=30.0)
+        await config.cache.async_wait_for_cache_sync(timeout=30.0)
 
         # Get informers for different resource types
         cm_informer = config.cache.get_informer(k8s.core.v1.ConfigMap)
@@ -567,7 +567,7 @@ async def test_async_informer_reconnection(test_config):
         ).async_create()
 
         # Wait for initial sync
-        await config.cache.async_wait_for_sync(timeout=30.0)
+        await config.cache.async_wait_for_cache_sync(timeout=30.0)
 
         informer = config.cache.get_informer(k8s.core.v1.ConfigMap)
         assert informer is not None
@@ -681,7 +681,7 @@ async def test_async_cache_disabled(test_config):
         assert informer is None
 
         # Wait for sync should return True immediately
-        assert await config.cache.async_wait_for_sync(timeout=1.0)
+        assert await config.cache.async_wait_for_cache_sync(timeout=1.0)
 
 
 @pytest.mark.configure_test_cluster(
@@ -710,7 +710,7 @@ async def test_async_namespace_scoped_informer(test_config):
 
     async with config:
         # Wait for cache to sync
-        await config.cache.async_wait_for_sync(timeout=30.0)
+        await config.cache.async_wait_for_cache_sync(timeout=30.0)
 
         # Get namespace-scoped informers
         # These should create different informers scoped to each namespace

--- a/tests/test_informers.py
+++ b/tests/test_informers.py
@@ -34,7 +34,7 @@ async def test_async_cache_basic_functionality(test_config):
         ).async_create()
 
         # Wait for cache to sync
-        assert await config.cache.async_wait_for_cache_sync(timeout=30.0)
+        assert await config.cache.async_wait(timeout=30.0)
         assert config.cache.ready()
 
         # Test cache status
@@ -88,7 +88,7 @@ def test_sync_cache_basic_functionality(test_config):
         ns = k8s.core.v1.Namespace(metadata=ObjectMeta(generate_name="test-cache-")).create()
 
         # Wait for cache to sync
-        assert config.cache.wait_for_cache_sync(timeout=30.0)
+        assert config.cache.wait(timeout=30.0)
         assert config.cache.ready()
 
         # Get informer for ConfigMaps
@@ -164,7 +164,7 @@ async def test_async_informer_event_handlers(test_config):
         informer.on_delete(handle_delete)
 
         # Wait for sync
-        await config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await config.cache.async_wait(timeout=30.0)
 
         # Create a ConfigMap
         cm = await k8s.core.v1.ConfigMap(
@@ -231,7 +231,7 @@ async def test_async_informer_filtering(test_config):
 
     async with config:
         # Wait for cache to sync
-        await config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await config.cache.async_wait(timeout=30.0)
 
         # Get informer
         informer = config.cache.get_informer(k8s.core.v1.ConfigMap)
@@ -294,7 +294,7 @@ async def test_async_informer_custom_indexing(test_config):
         informer.add_index("by_data_key", index_by_data_key)
 
         # Wait for sync
-        await config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await config.cache.async_wait(timeout=30.0)
 
         # Create ConfigMaps with different data keys
         cm1 = await k8s.core.v1.ConfigMap(
@@ -349,7 +349,7 @@ async def test_async_cache_modes(test_config):
         ).async_create()
 
         # In strict mode, operations should use cache only after sync
-        await strict_config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await strict_config.cache.async_wait(timeout=30.0)
 
         # Create a ConfigMap through API (not cache)
         cm = await k8s.core.v1.ConfigMap(
@@ -376,7 +376,7 @@ async def test_async_cache_modes(test_config):
         ).async_create()
 
         # Wait for cache sync
-        await fallback_config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await fallback_config.cache.async_wait(timeout=30.0)
 
         # Create a ConfigMap
         cm = await k8s.core.v1.ConfigMap(
@@ -406,7 +406,7 @@ async def test_async_cache_context_managers(test_config):
     config = test_config.with_cache(cache_config)
 
     async with config:
-        await config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await config.cache.async_wait(timeout=30.0)
 
         # Test pause context manager
         assert config.cache.enabled
@@ -467,7 +467,7 @@ async def test_async_cache_performance_comparison(test_config):
     # Test performance with cache
     async with cached_config:
         # Wait for cache to sync
-        await cached_config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await cached_config.cache.async_wait(timeout=30.0)
 
         informer = cached_config.cache.get_informer(k8s.core.v1.ConfigMap)
         assert informer is not None
@@ -510,7 +510,7 @@ async def test_async_multiple_resource_types(test_config):
         ).async_create()
 
         # Wait for cache to sync
-        await config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await config.cache.async_wait(timeout=30.0)
 
         # Get informers for different resource types
         cm_informer = config.cache.get_informer(k8s.core.v1.ConfigMap)
@@ -567,7 +567,7 @@ async def test_async_informer_reconnection(test_config):
         ).async_create()
 
         # Wait for initial sync
-        await config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await config.cache.async_wait(timeout=30.0)
 
         informer = config.cache.get_informer(k8s.core.v1.ConfigMap)
         assert informer is not None
@@ -632,7 +632,7 @@ def test_sync_informer_event_handlers(test_config):
         informer.on_delete(handle_delete)
 
         # Wait for sync
-        config.cache.wait_for_cache_sync(timeout=30.0)
+        config.cache.wait(timeout=30.0)
 
         # Create a ConfigMap
         cm = k8s.core.v1.ConfigMap(
@@ -681,7 +681,7 @@ async def test_async_cache_disabled(test_config):
         assert informer is None
 
         # Wait for sync should return True immediately
-        assert await config.cache.async_wait_for_cache_sync(timeout=1.0)
+        assert await config.cache.async_wait(timeout=1.0)
 
 
 @pytest.mark.configure_test_cluster(
@@ -710,7 +710,7 @@ async def test_async_namespace_scoped_informer(test_config):
 
     async with config:
         # Wait for cache to sync
-        await config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await config.cache.async_wait(timeout=30.0)
 
         # Get namespace-scoped informers
         # These should create different informers scoped to each namespace

--- a/tests/test_informers_edge_cases.py
+++ b/tests/test_informers_edge_cases.py
@@ -482,7 +482,7 @@ def test_sync_informer_basic_patterns(test_config):
         ns = k8s.core.v1.Namespace(metadata=ObjectMeta(generate_name="test-sync-basic-")).create()
 
         # Wait for sync
-        assert config.cache.sync_wait_for_sync(timeout=30.0)
+        assert config.cache.wait_for_cache_sync(timeout=30.0)
 
         # Get sync informer
         informer = config.cache.get_informer(k8s.core.v1.ConfigMap, sync=True)

--- a/tests/test_informers_edge_cases.py
+++ b/tests/test_informers_edge_cases.py
@@ -33,7 +33,7 @@ async def test_async_informer_large_dataset(test_config):
         ).async_create()
 
         # Wait for cache to sync
-        await config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await config.cache.async_wait(timeout=30.0)
         informer = config.cache.get_informer(k8s.core.v1.ConfigMap)
         assert informer is not None
 
@@ -126,7 +126,7 @@ async def test_async_informer_rapid_updates(test_config):
             if new_obj.metadata and new_obj.metadata.name:
                 final_values[new_obj.metadata.name] = new_obj.data.copy() if new_obj.data else {}
 
-        await config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await config.cache.async_wait(timeout=30.0)
 
         # Create initial ConfigMap
         cm = await k8s.core.v1.ConfigMap(
@@ -179,7 +179,7 @@ async def test_async_informer_complex_selectors(test_config):
             metadata=ObjectMeta(generate_name="test-complex-")
         ).async_create()
 
-        await config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await config.cache.async_wait(timeout=30.0)
         informer = config.cache.get_informer(k8s.core.v1.ConfigMap)
         assert informer is not None
 
@@ -267,7 +267,7 @@ async def test_async_informer_error_handling(test_config):
                 error_count += 1
                 raise RuntimeError("Simulated handler error")
 
-        await config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await config.cache.async_wait(timeout=30.0)
 
         # Create ConfigMaps, some that will trigger errors
         cm_normal = await k8s.core.v1.ConfigMap(
@@ -311,7 +311,7 @@ async def test_async_informer_concurrent_operations(test_config):
             metadata=ObjectMeta(generate_name="test-concurrent-")
         ).async_create()
 
-        await config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await config.cache.async_wait(timeout=30.0)
         informer = config.cache.get_informer(k8s.core.v1.ConfigMap)
         assert informer is not None
 
@@ -377,7 +377,7 @@ async def test_async_informer_memory_efficiency(test_config):
             metadata=ObjectMeta(generate_name="test-memory-")
         ).async_create()
 
-        await config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await config.cache.async_wait(timeout=30.0)
         informer = config.cache.get_informer(k8s.core.v1.ConfigMap)
         assert informer is not None
 
@@ -436,7 +436,7 @@ async def test_async_informer_resource_version_handling(test_config):
             metadata=ObjectMeta(generate_name="test-rv-")
         ).async_create()
 
-        await config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await config.cache.async_wait(timeout=30.0)
         informer = config.cache.get_informer(k8s.core.v1.ConfigMap)
         assert informer is not None
 
@@ -482,7 +482,7 @@ def test_sync_informer_basic_patterns(test_config):
         ns = k8s.core.v1.Namespace(metadata=ObjectMeta(generate_name="test-sync-basic-")).create()
 
         # Wait for sync
-        assert config.cache.wait_for_cache_sync(timeout=30.0)
+        assert config.cache.wait(timeout=30.0)
 
         # Get sync informer
         informer = config.cache.get_informer(k8s.core.v1.ConfigMap, sync=True)
@@ -521,7 +521,7 @@ async def test_async_cache_integration_with_resource_operations(test_config):
             metadata=ObjectMeta(generate_name="test-integration-")
         ).async_create()
 
-        await config.cache.async_wait_for_cache_sync(timeout=30.0)
+        await config.cache.async_wait(timeout=30.0)
 
         # In fallback mode, get operations should try cache first, then API
         # This test documents expected behavior for future integration

--- a/tests/test_informers_edge_cases.py
+++ b/tests/test_informers_edge_cases.py
@@ -33,7 +33,7 @@ async def test_async_informer_large_dataset(test_config):
         ).async_create()
 
         # Wait for cache to sync
-        await config.cache.async_wait_for_sync(timeout=30.0)
+        await config.cache.async_wait_for_cache_sync(timeout=30.0)
         informer = config.cache.get_informer(k8s.core.v1.ConfigMap)
         assert informer is not None
 
@@ -126,7 +126,7 @@ async def test_async_informer_rapid_updates(test_config):
             if new_obj.metadata and new_obj.metadata.name:
                 final_values[new_obj.metadata.name] = new_obj.data.copy() if new_obj.data else {}
 
-        await config.cache.async_wait_for_sync(timeout=30.0)
+        await config.cache.async_wait_for_cache_sync(timeout=30.0)
 
         # Create initial ConfigMap
         cm = await k8s.core.v1.ConfigMap(
@@ -179,7 +179,7 @@ async def test_async_informer_complex_selectors(test_config):
             metadata=ObjectMeta(generate_name="test-complex-")
         ).async_create()
 
-        await config.cache.async_wait_for_sync(timeout=30.0)
+        await config.cache.async_wait_for_cache_sync(timeout=30.0)
         informer = config.cache.get_informer(k8s.core.v1.ConfigMap)
         assert informer is not None
 
@@ -267,7 +267,7 @@ async def test_async_informer_error_handling(test_config):
                 error_count += 1
                 raise RuntimeError("Simulated handler error")
 
-        await config.cache.async_wait_for_sync(timeout=30.0)
+        await config.cache.async_wait_for_cache_sync(timeout=30.0)
 
         # Create ConfigMaps, some that will trigger errors
         cm_normal = await k8s.core.v1.ConfigMap(
@@ -311,7 +311,7 @@ async def test_async_informer_concurrent_operations(test_config):
             metadata=ObjectMeta(generate_name="test-concurrent-")
         ).async_create()
 
-        await config.cache.async_wait_for_sync(timeout=30.0)
+        await config.cache.async_wait_for_cache_sync(timeout=30.0)
         informer = config.cache.get_informer(k8s.core.v1.ConfigMap)
         assert informer is not None
 
@@ -377,7 +377,7 @@ async def test_async_informer_memory_efficiency(test_config):
             metadata=ObjectMeta(generate_name="test-memory-")
         ).async_create()
 
-        await config.cache.async_wait_for_sync(timeout=30.0)
+        await config.cache.async_wait_for_cache_sync(timeout=30.0)
         informer = config.cache.get_informer(k8s.core.v1.ConfigMap)
         assert informer is not None
 
@@ -436,7 +436,7 @@ async def test_async_informer_resource_version_handling(test_config):
             metadata=ObjectMeta(generate_name="test-rv-")
         ).async_create()
 
-        await config.cache.async_wait_for_sync(timeout=30.0)
+        await config.cache.async_wait_for_cache_sync(timeout=30.0)
         informer = config.cache.get_informer(k8s.core.v1.ConfigMap)
         assert informer is not None
 
@@ -521,7 +521,7 @@ async def test_async_cache_integration_with_resource_operations(test_config):
             metadata=ObjectMeta(generate_name="test-integration-")
         ).async_create()
 
-        await config.cache.async_wait_for_sync(timeout=30.0)
+        await config.cache.async_wait_for_cache_sync(timeout=30.0)
 
         # In fallback mode, get operations should try cache first, then API
         # This test documents expected behavior for future integration


### PR DESCRIPTION
## Summary
- Fixed naming inconsistencies in the informer/caching API to follow CloudCoil's established patterns
- Ensures consistent async-first naming convention across the caching module

## Changes

### Cache class
- Renamed `sync_wait_for_sync()` to `wait_for_cache_sync()` to avoid conflict with the `wait_for_sync` boolean configuration field

### ConcurrentStore methods
- **Sync methods**: Removed `sync_` prefix to follow standard naming
  - `sync_add()` → `add()`
  - `sync_delete()` → `delete()`
  - `sync_replace()` → `replace()`
  
- **Async methods**: Added `async_` prefix per CloudCoil convention
  - `add()` → `async_add()`
  - `delete()` → `async_delete()`
  - `replace()` → `async_replace()`

### Updated all callers
- AsyncInformer now calls `async_add()`, `async_delete()`, `async_replace()`
- SyncInformer wrapper calls `add()`, `delete()`, `replace()`

## Test plan
- [x] Run linter and type checker (`make lint`) - all checks pass
- [ ] Run existing informer tests to ensure no regressions
- [ ] Verify cache functionality still works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)